### PR TITLE
Make skeptic an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-skeptic = "0.13"
+skeptic = { version = "0.13", optional = true }
 
 [dev-dependencies]
 permutator = "0.3"
@@ -27,6 +27,13 @@ criterion = "0.2"
 rand = "0.6"
 chrono = "0.4" # For examples
 skeptic = "0.13"
+
+[features]
+# Skeptic is only needed for doc generation.
+# Gate it on an optional-but-default feature
+# that people can disable if they don't want
+# to pull in skeptic and all of its dependencies.
+default = ["skeptic"]
 
 [[bench]]
 name = "kitchen_sink"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
+#[cfg(feature="skeptic")]
 extern crate skeptic;
 
 fn main() {
     // Generate doc tests for `README.md`.
+    #[cfg(feature="skeptic")]
     skeptic::generate_doc_tests(&["README.md"]);
 }


### PR DESCRIPTION
But enable it by default.

This lets people opt out of building 'skeptic' and all its dependencies
if they're just trying to use the library itself, but not document or test it.

Fixes https://github.com/jeffparsons/rangemap/issues/12