### PR TITLE
Bump MSRV to 1.43.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: rust
 rust:
   # Don't forget to update in README and documentation.
-  - 1.32.0
+  - 1.43.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rangemap"
 version = "0.1.5"
+rust = "1.43"
 authors = ["Jeff Parsons <jeff@parsons.io>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docs](https://docs.rs/rangemap/badge.svg)](https://docs.rs/rangemap)
 [![Build status](https://travis-ci.org/jeffparsons/rangemap.svg?branch=master)](https://travis-ci.org/jeffparsons/rangemap)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/jeffparsons/rangemap?svg=true)](https://ci.appveyor.com/project/jeffparsons/rangemap)
-[![Rust](https://img.shields.io/badge/rust-1.32%2B-blue.svg?maxAge=3600)](https://github.com/jeffparsons/rangemap) <!-- Don't forget to update the Travis config when bumping minimum Rust version. -->
+[![Rust](https://img.shields.io/badge/rust-1.43%2B-blue.svg?maxAge=3600)](https://github.com/jeffparsons/rangemap) <!-- Don't forget to update the Travis config when bumping minimum Rust version. -->
 
 
 [RangeMap](https://docs.rs/rangemap/latest/rangemap/struct.RangeMap.html) is a map data structure whose keys are stored as ranges. Contiguous and overlapping ranges that map to the same value are coalesced into a single range.


### PR DESCRIPTION
This supports the two latest stable releases.

I'm not going to bother with longer-term support for old Rust
compiler versions unless anyone indicates that they're stuck on
one for some reason.