### PR TITLE
Add RangeInclusiveMap type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rangemap"
 version = "0.1.5"
-rust = "1.43"
 authors = ["Jeff Parsons <jeff@parsons.io>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ categories = ["data-structures"]
 build = "build.rs"
 
 [dependencies]
+# TODO: Make this an optional dependency based on default "rangeinclusive" feature.
+num = "0.3"
 
 [build-dependencies]
 skeptic = { version = "0.13", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ categories = ["data-structures"]
 build = "build.rs"
 
 [dependencies]
-# TODO: Make this an optional dependency based on default "rangeinclusive" feature.
-num = "0.3"
 
 [build-dependencies]
 skeptic = { version = "0.13", optional = true }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/github/jeffparsons/rangemap?svg=true)](https://ci.appveyor.com/project/jeffparsons/rangemap)
 [![Rust](https://img.shields.io/badge/rust-1.43%2B-blue.svg?maxAge=3600)](https://github.com/jeffparsons/rangemap) <!-- Don't forget to update the Travis config when bumping minimum Rust version. -->
 
+[`RangeMap`] and [`RangeInclusiveMap`] are map data structures whose keys
+are stored as ranges. Contiguous and overlapping ranges that map to the same
+value are coalesced into a single range.
 
-[RangeMap](https://docs.rs/rangemap/latest/rangemap/struct.RangeMap.html) is a map data structure whose keys are stored as ranges. Contiguous and overlapping ranges that map to the same value are coalesced into a single range.
+Corresponding [`RangeSet`] and [`RangeInclusiveSet`] structures are also provided.
 
-A corresponding [RangeSet](https://docs.rs/rangemap/latest/rangemap/struct.RangeSet.html) structure is also provided.
+[`RangeMap`]: https://docs.rs/rangemap/latest/rangemap/struct.RangeMap.html
+[`RangeInclusiveMap`]: https://docs.rs/rangemap/latest/rangemap/struct.RangeInclusiveMap.html
+[`RangeSet`]: https://docs.rs/rangemap/latest/rangemap/struct.RangeSet.html
+[`RangeInclusiveSet`]: https://docs.rs/rangemap/latest/rangemap/struct.RangeInclusiveSet.html
+
 
 ## Example: use with Chrono
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ environment:
     - APPVEYOR_RUST_CHANNEL: stable
     - APPVEYOR_RUST_CHANNEL: nightly
 
+matrix:
+  allow_failures:
+    - APPVEYOR_RUST_CHANNEL: nightly
+
 install:
   # Install Rust, x86_64-pc-windows-msvc host
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/

--- a/benches/kitchen_sink.rs
+++ b/benches/kitchen_sink.rs
@@ -15,7 +15,7 @@ fn kitchen_sink(kvs: &[(Range<i32>, bool)]) {
         if remove {
             range_map.remove(range.clone());
         } else {
-            range_map.insert(range.clone(), value.clone());
+            range_map.insert(range.clone(), *value);
         }
         remove = !remove;
     }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
-#[cfg(feature="skeptic")]
+#[cfg(feature = "skeptic")]
 extern crate skeptic;
 
 fn main() {
     // Generate doc tests for `README.md`.
-    #[cfg(feature="skeptic")]
+    #[cfg(feature = "skeptic")]
     skeptic::generate_doc_tests(&["README.md"]);
 }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -16,10 +16,10 @@ use std::ops::RangeInclusive;
 /// because adjacent ranges can be detected using equality of range ends alone.)
 ///
 /// You can provide these functions either by implementing the
-/// [StepLite](crate::StepLite) trait for your key type `K`, or,
+/// [`StepLite`](crate::StepLite) trait for your key type `K`, or,
 /// if this is impossible because of Rust's "orphan rules",
 /// you can provide equivalent free functions using the `StepsFnsT` type parameter.
-/// [StepLite](crate::StepLite) is implemented for all standard integer types,
+/// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
 #[derive(Clone)]
 pub struct RangeInclusiveMap<K, V, StepFnsT = K> {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -57,10 +57,7 @@ where
             .filter(|(range_start_wrapper, _value)| {
                 // Does the only candidate range contain
                 // the requested key?
-                //
-                // TODO: Use `contains` once https://github.com/rust-lang/rust/issues/32311
-                // is stabilized.
-                range_start_wrapper.range.contains_item(key)
+                range_start_wrapper.range.contains(key)
             })
             .map(|(range_start_wrapper, value)| (&range_start_wrapper.range, value))
     }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1,20 +1,21 @@
-use super::range_wrapper::RangeStartWrapper;
+use super::range_wrapper::RangeInclusiveStartWrapper;
 use crate::std_ext::*;
+use num::Bounded;
 use std::collections::BTreeMap;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 #[derive(Clone)]
-/// A map whose keys are stored as (half-open) ranges.
+/// A map whose keys are stored as (closed) ranges.
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-pub struct RangeMap<K, V> {
+pub struct RangeInclusiveMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
-    btm: BTreeMap<RangeStartWrapper<K>, V>,
+    btm: BTreeMap<RangeInclusiveStartWrapper<K>, V>,
 }
 
-impl<K, V> Default for RangeMap<K, V>
+impl<K, V> Default for RangeInclusiveMap<K, V>
 where
     K: Ord + Clone,
     V: Eq + Clone,
@@ -24,14 +25,14 @@ where
     }
 }
 
-impl<K, V> RangeMap<K, V>
+impl<K, V> RangeInclusiveMap<K, V>
 where
     K: Ord + Clone,
     V: Eq + Clone,
 {
-    /// Makes a new empty `RangeMap`.
+    /// Makes a new empty `RangeInclusiveMap`.
     pub fn new() -> Self {
-        RangeMap {
+        RangeInclusiveMap {
             btm: BTreeMap::new(),
         }
     }
@@ -44,12 +45,12 @@ where
 
     /// Returns the range-value pair (as a pair of references) corresponding
     /// to the given key, if the key is covered by any range in the map.
-    pub fn get_key_value(&self, key: &K) -> Option<(&Range<K>, &V)> {
+    pub fn get_key_value(&self, key: &K) -> Option<(&RangeInclusive<K>, &V)> {
         use std::ops::Bound;
 
         // The only stored range that could contain the given key is the
         // last stored range whose start is less than or equal to this key.
-        let key_as_start = RangeStartWrapper::new(key.clone()..key.clone());
+        let key_as_start = RangeInclusiveStartWrapper::new(key.clone()..=key.clone());
         self.btm
             .range((Bound::Unbounded, Bound::Included(key_as_start)))
             .next_back()
@@ -72,8 +73,8 @@ where
     /// Gets an iterator over all pairs of key range and value,
     /// ordered by key range.
     ///
-    /// The iterator element type is `(&'a Range<K>, &'a V)`.
-    pub fn iter(&self) -> impl Iterator<Item = (&Range<K>, &V)> {
+    /// The iterator element type is `(&'a RangeInclusive<K>, &'a V)`.
+    pub fn iter(&self) -> impl Iterator<Item = (&RangeInclusive<K>, &V)> {
         self.btm.iter().map(|(by_start, v)| (&by_start.range, v))
     }
 
@@ -89,25 +90,35 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if range `start >= end`.
-    pub fn insert(&mut self, range: Range<K>, value: V) {
+    /// Panics if range `start > end`.
+    pub fn insert(&mut self, range: RangeInclusive<K>, value: V)
+    where
+        K: StepLite + Bounded,
+    {
         use std::ops::Bound;
 
-        // We don't want to have to make empty ranges make sense;
-        // they don't represent anything meaningful in this structure.
-        assert!(range.start < range.end);
+        // Backwards ranges don't make sense.
+        // `RangeInclusive` doesn't enforce this,
+        // and we don't want weird explosions further down
+        // if someone gives us such a range.
+        assert!(
+            range.start() <= range.end(),
+            "Range start can not be after range end"
+        );
 
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.
         // See `range_wrapper.rs` for explanation of these hacks.
-        let mut new_range_start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
+        let mut new_range_start_wrapper: RangeInclusiveStartWrapper<K> =
+            RangeInclusiveStartWrapper::new(range);
         let new_value = value;
 
         // Is there a stored range either overlapping the start of
         // the range to insert or immediately preceding it?
         //
         // If there is any such stored range, it will be the last
-        // whose start is less than or equal to the start of the range to insert.
+        // whose start is less than or equal to _one less than_
+        // the start of the range to insert.
         if let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
             .range((Bound::Unbounded, Bound::Included(&new_range_start_wrapper)))
@@ -138,28 +149,35 @@ where
         //
         // If there are any such stored ranges (that weren't already caught above),
         // their starts will fall somewhere after the start of the range to insert,
-        // and on or before its end.
+        // and on, before, or _immediately after_ its end.
         //
-        // This time around, if the latter holds, it also implies
-        // the former so we don't need to check here if they touch.
+        // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeInclusiveStartWrapper<T>`
+        // and use that to search here, to avoid constructing another `RangeInclusiveStartWrapper`.
         //
-        // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeStartWrapper<T>`
-        // and use that to search here, to avoid constructing another `RangeStartWrapper`.
-        let new_range_end_as_start = RangeStartWrapper::new(
-            new_range_start_wrapper.range.end.clone()..new_range_start_wrapper.range.end.clone(),
-        );
+        // (One exception is if we're at the end of the key space.)
+        let last_possible_start = if *new_range_start_wrapper.range.end() == K::max_value() {
+            // Can't look beyond this, or we'd cause arithmetic overflow.
+            new_range_start_wrapper.range.end().clone()
+        } else {
+            // There exists key space beyond this value; the start of a
+            // range we're interested in could be immediately after
+            // the end of the range to insert.
+            new_range_start_wrapper.range.end().add_one()
+        };
+        let last_possible_start =
+            RangeInclusiveStartWrapper::new(last_possible_start.clone()..=last_possible_start);
         while let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
             .range((
                 Bound::Excluded(&new_range_start_wrapper),
-                Bound::Included(&new_range_end_as_start),
+                Bound::Included(&last_possible_start),
             ))
             .next()
         {
             // One extra exception: if we have different values,
-            // and the stored range starts at the end of the range to insert,
+            // and the stored range starts immediately following the end of the range to insert,
             // then we don't want to keep looping forever trying to find more!
-            if stored_range_start_wrapper.range.start == new_range_start_wrapper.range.end
+            if stored_range_start_wrapper.range.start() == last_possible_start.range.start()
                 && *stored_value != new_value
             {
                 break;
@@ -189,15 +207,24 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if range `start >= end`.
-    pub fn remove(&mut self, range: Range<K>) {
+    /// Panics if range `start > end`.
+    pub fn remove(&mut self, range: RangeInclusive<K>)
+    where
+        K: StepLite,
+    {
         use std::ops::Bound;
 
-        // We don't want to have to make empty ranges make sense;
-        // they don't represent anything meaningful in this structure.
-        assert!(range.start < range.end);
+        // Backwards ranges don't make sense.
+        // `RangeInclusive` doesn't enforce this,
+        // and we don't want weird explosions further down
+        // if someone gives us such a range.
+        assert!(
+            range.start() <= range.end(),
+            "Range start can not be after range end"
+        );
 
-        let range_start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
+        let range_start_wrapper: RangeInclusiveStartWrapper<K> =
+            RangeInclusiveStartWrapper::new(range);
         let range = &range_start_wrapper.range;
 
         // Is there a stored range overlapping the start of
@@ -229,16 +256,17 @@ where
         //
         // If there are any such stored ranges (that weren't already caught above),
         // their starts will fall somewhere after the start of the range to insert,
-        // and before its end.
+        // and on or before its end.
         //
-        // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeStartWrapper<T>`
-        // and use that to search here, to avoid constructing another `RangeStartWrapper`.
-        let new_range_end_as_start = RangeStartWrapper::new(range.end.clone()..range.end.clone());
+        // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeInclusiveStartWrapper<T>`
+        // and use that to search here, to avoid constructing another `RangeInclusiveStartWrapper`.
+        let new_range_end_as_start =
+            RangeInclusiveStartWrapper::new(range.end().clone()..=range.end().clone());
         while let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
             .range((
                 Bound::Excluded(&range_start_wrapper),
-                Bound::Excluded(&new_range_end_as_start),
+                Bound::Included(&new_range_end_as_start),
             ))
             .next()
             .map(|(stored_range_start_wrapper, stored_value)| {
@@ -255,11 +283,13 @@ where
 
     fn adjust_touching_ranges_for_insert(
         &mut self,
-        stored_range_start_wrapper: RangeStartWrapper<K>,
+        stored_range_start_wrapper: RangeInclusiveStartWrapper<K>,
         stored_value: V,
-        new_range: &mut Range<K>,
+        new_range: &mut RangeInclusive<K>,
         new_value: &V,
-    ) {
+    ) where
+        K: StepLite,
+    {
         use std::cmp::{max, min};
 
         if stored_value == *new_value {
@@ -269,9 +299,10 @@ where
             // This means that no matter how big or where the stored range is,
             // we will expand the new range's bounds to subsume it,
             // and then delete the stored range.
-            new_range.start =
-                min(&new_range.start, &stored_range_start_wrapper.range.start).clone();
-            new_range.end = max(&new_range.end, &stored_range_start_wrapper.range.end).clone();
+            let new_start =
+                min(new_range.start(), stored_range_start_wrapper.range.start()).clone();
+            let new_end = max(new_range.end(), stored_range_start_wrapper.range.end()).clone();
+            *new_range = new_start..=new_end;
             self.btm.remove(&stored_range_start_wrapper);
         } else {
             // The ranges have different values.
@@ -280,20 +311,22 @@ where
                 // Delete the stored range, and then add back between
                 // 0 and 2 subranges at the ends of the range to insert.
                 self.btm.remove(&stored_range_start_wrapper);
-                if stored_range_start_wrapper.range.start < new_range.start {
+                if stored_range_start_wrapper.range.start() < new_range.start() {
                     // Insert the piece left of the range to insert.
                     self.btm.insert(
-                        RangeStartWrapper::new(
-                            stored_range_start_wrapper.range.start..new_range.start.clone(),
+                        RangeInclusiveStartWrapper::new(
+                            stored_range_start_wrapper.range.start().clone()
+                                ..=new_range.start().sub_one(),
                         ),
                         stored_value.clone(),
                     );
                 }
-                if stored_range_start_wrapper.range.end > new_range.end {
+                if stored_range_start_wrapper.range.end() > new_range.end() {
                     // Insert the piece right of the range to insert.
                     self.btm.insert(
-                        RangeStartWrapper::new(
-                            new_range.end.clone()..stored_range_start_wrapper.range.end,
+                        RangeInclusiveStartWrapper::new(
+                            new_range.end().add_one()
+                                ..=stored_range_start_wrapper.range.end().clone(),
                         ),
                         stored_value,
                     );
@@ -307,25 +340,31 @@ where
 
     fn adjust_overlapping_ranges_for_remove(
         &mut self,
-        stored_range_start_wrapper: RangeStartWrapper<K>,
+        stored_range_start_wrapper: RangeInclusiveStartWrapper<K>,
         stored_value: V,
-        range_to_remove: &Range<K>,
-    ) {
+        range_to_remove: &RangeInclusive<K>,
+    ) where
+        K: StepLite,
+    {
         // Delete the stored range, and then add back between
         // 0 and 2 subranges at the ends of the range to insert.
         self.btm.remove(&stored_range_start_wrapper);
         let stored_range = stored_range_start_wrapper.range;
-        if stored_range.start < range_to_remove.start {
+        if stored_range.start() < range_to_remove.start() {
             // Insert the piece left of the range to insert.
             self.btm.insert(
-                RangeStartWrapper::new(stored_range.start..range_to_remove.start.clone()),
+                RangeInclusiveStartWrapper::new(
+                    stored_range.start().clone()..=range_to_remove.start().sub_one(),
+                ),
                 stored_value.clone(),
             );
         }
-        if stored_range.end > range_to_remove.end {
+        if stored_range.end() > range_to_remove.end() {
             // Insert the piece right of the range to insert.
             self.btm.insert(
-                RangeStartWrapper::new(range_to_remove.end.clone()..stored_range.end),
+                RangeInclusiveStartWrapper::new(
+                    range_to_remove.end().add_one()..=stored_range.end().clone(),
+                ),
                 stored_value,
             );
         }
@@ -336,16 +375,16 @@ where
 mod tests {
     use super::*;
 
-    trait RangeMapExt<K, V> {
-        fn to_vec(&self) -> Vec<(Range<K>, V)>;
+    trait RangeInclusiveMapExt<K, V> {
+        fn to_vec(&self) -> Vec<(RangeInclusive<K>, V)>;
     }
 
-    impl<K, V> RangeMapExt<K, V> for RangeMap<K, V>
+    impl<K, V> RangeInclusiveMapExt<K, V> for RangeInclusiveMap<K, V>
     where
         K: Ord + Clone,
         V: Eq + Clone,
     {
-        fn to_vec(&self) -> Vec<(Range<K>, V)> {
+        fn to_vec(&self) -> Vec<(RangeInclusive<K>, V)> {
             self.iter().map(|(kr, v)| (kr.clone(), v.clone())).collect()
         }
     }
@@ -356,134 +395,134 @@ mod tests {
 
     #[test]
     fn empty_map_is_empty() {
-        let range_map: RangeMap<u32, bool> = RangeMap::new();
+        let range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         assert_eq!(range_map.to_vec(), vec![]);
     }
 
     #[test]
     fn insert_into_empty_map() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(0..50, false);
-        assert_eq!(range_map.to_vec(), vec![(0..50, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=50, false);
+        assert_eq!(range_map.to_vec(), vec![(0..=50, false)]);
     }
 
     #[test]
     fn new_same_value_immediately_following_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..3, false);
+        // ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=3, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ◌ ●---◌ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, false);
+        // ◌ ◌ ◌ ◌ ●---◌ ◌ ◌ ◌
+        range_map.insert(4..=6, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-------◌ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..5, false)]);
+        // ◌ ●---------◌ ◌ ◌ ◌
+        assert_eq!(range_map.to_vec(), vec![(1..=6, false)]);
     }
 
     #[test]
     fn new_different_value_immediately_following_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..3, false);
+        // ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=3, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, true);
+        // ◌ ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌
+        range_map.insert(4..=6, true);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..3, false), (3..5, true)]);
+        // ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        // ◌ ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌
+        assert_eq!(range_map.to_vec(), vec![(1..=3, false), (4..=6, true)]);
     }
 
     #[test]
     fn new_same_value_overlapping_end_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-----◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..4, false);
+        // ◌ ●-----● ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=4, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ◌ ●---◌ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, false);
+        // ◌ ◌ ◌ ◌ ●---● ◌ ◌ ◌
+        range_map.insert(4..=6, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-------◌ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..5, false)]);
+        // ◌ ●---------● ◌ ◌ ◌
+        assert_eq!(range_map.to_vec(), vec![(1..=6, false)]);
     }
 
     #[test]
     fn new_different_value_overlapping_end_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-----◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..4, false);
+        // ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=3, false);
         // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◆---◆ ◌ ◌ ◌ ◌
+        range_map.insert(3..=5, true);
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌
         // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, true);
-        // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..3, false), (3..5, true)]);
+        assert_eq!(range_map.to_vec(), vec![(1..=2, false), (3..=5, true)]);
     }
 
     #[test]
     fn new_same_value_immediately_preceding_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ◌ ●---◌ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, false);
+        // ◌ ◌ ◌ ●---● ◌ ◌ ◌ ◌
+        range_map.insert(3..=5, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..3, false);
+        // ◌ ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=2, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-------◌ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..5, false)]);
+        // ◌ ●-------● ◌ ◌ ◌ ◌
+        assert_eq!(range_map.to_vec(), vec![(1..=5, false)]);
     }
 
     #[test]
     fn new_different_value_immediately_preceding_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◆---◆ ◌ ◌ ◌ ◌
+        range_map.insert(3..=5, true);
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=2, false);
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌
         // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        range_map.insert(3..5, true);
-        // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..3, false);
-        // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        // ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..3, false), (3..5, true)]);
+        assert_eq!(range_map.to_vec(), vec![(1..=2, false), (3..=5, true)]);
     }
 
     #[test]
     fn new_same_value_wholly_inside_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-------◌ ◌ ◌ ◌ ◌
-        range_map.insert(1..5, false);
+        // ◌ ●-------● ◌ ◌ ◌ ◌
+        range_map.insert(1..=5, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(2..4, false);
+        // ◌ ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..=4, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-------◌ ◌ ◌ ◌ ◌
-        assert_eq!(range_map.to_vec(), vec![(1..5, false)]);
+        // ◌ ●-------● ◌ ◌ ◌ ◌
+        assert_eq!(range_map.to_vec(), vec![(1..=5, false)]);
     }
 
     #[test]
     fn new_different_value_wholly_inside_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◆-------◇ ◌ ◌ ◌ ◌
-        range_map.insert(1..5, true);
+        // ◌ ◆-------◆ ◌ ◌ ◌ ◌
+        range_map.insert(1..=5, true);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
-        range_map.insert(2..4, false);
+        // ◌ ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..=4, false);
         // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ●-◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
-        // ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌ ◌
-        // ◌ ◌ ◌ ◌ ●-◌ ◌ ◌ ◌ ◌
+        // ◌ ◆ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        // ◌ ◌ ●---● ◌ ◌ ◌ ◌ ◌
+        // ◌ ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌
         assert_eq!(
             range_map.to_vec(),
-            vec![(1..2, true), (2..4, false), (4..5, true)]
+            vec![(1..=1, true), (2..=4, false), (5..=5, true)]
         );
     }
 
@@ -494,28 +533,28 @@ mod tests {
         use permutator::Permutation;
 
         let mut ranges_with_values = [
-            (2..3, false),
-            // A duplicate duplicates
-            (2..3, false),
+            (2..=3, false),
+            // A duplicate range
+            (2..=3, false),
             // Almost a duplicate, but with a different value
-            (2..3, true),
+            (2..=3, true),
             // A few small ranges, some of them overlapping others,
             // some of them touching others
-            (3..5, true),
-            (4..6, true),
-            (5..7, true),
+            (3..=5, true),
+            (4..=6, true),
+            (6..=7, true),
             // A really big range
-            (2..6, true),
+            (2..=6, true),
         ];
 
         ranges_with_values.permutation().for_each(|permutation| {
-            let mut range_map: RangeMap<u32, bool> = RangeMap::new();
+            let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
             let mut stupid: StupidU32RangeMap<bool> = StupidU32RangeMap::new();
 
             for (k, v) in permutation {
                 // Insert it into both maps.
                 range_map.insert(k.clone(), v);
-                stupid.insert(k.start..=(k.end - 1), v);
+                stupid.insert(k, v);
 
                 // At every step, both maps should contain the same stuff.
                 let stupid2: StupidU32RangeMap<bool> = range_map.clone().into();
@@ -530,18 +569,18 @@ mod tests {
 
     #[test]
     fn get() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(0..50, false);
-        assert_eq!(range_map.get(&49), Some(&false));
-        assert_eq!(range_map.get(&50), None);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=50, false);
+        assert_eq!(range_map.get(&50), Some(&false));
+        assert_eq!(range_map.get(&51), None);
     }
 
     #[test]
     fn get_key_value() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(0..50, false);
-        assert_eq!(range_map.get_key_value(&49), Some((&(0..50), &false)));
-        assert_eq!(range_map.get_key_value(&50), None);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=50, false);
+        assert_eq!(range_map.get_key_value(&50), Some((&(0..=50), &false)));
+        assert_eq!(range_map.get_key_value(&51), None);
     }
 
     //
@@ -550,64 +589,84 @@ mod tests {
 
     #[test]
     fn remove_from_empty_map() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.remove(0..50);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.remove(0..=50);
         assert_eq!(range_map.to_vec(), vec![]);
     }
 
     #[test]
     fn remove_non_covered_range_before_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(0..25);
-        assert_eq!(range_map.to_vec(), vec![(25..75, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(0..=24);
+        assert_eq!(range_map.to_vec(), vec![(25..=75, false)]);
     }
 
     #[test]
     fn remove_non_covered_range_after_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(75..100);
-        assert_eq!(range_map.to_vec(), vec![(25..75, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(76..=100);
+        assert_eq!(range_map.to_vec(), vec![(25..=75, false)]);
     }
 
     #[test]
     fn remove_overlapping_start_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(0..30);
-        assert_eq!(range_map.to_vec(), vec![(30..75, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(0..=25);
+        assert_eq!(range_map.to_vec(), vec![(26..=75, false)]);
     }
 
     #[test]
     fn remove_middle_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(30..70);
-        assert_eq!(range_map.to_vec(), vec![(25..30, false), (70..75, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(30..=70);
+        assert_eq!(range_map.to_vec(), vec![(25..=29, false), (71..=75, false)]);
     }
 
     #[test]
     fn remove_overlapping_end_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(70..100);
-        assert_eq!(range_map.to_vec(), vec![(25..70, false)]);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(75..=100);
+        assert_eq!(range_map.to_vec(), vec![(25..=74, false)]);
     }
 
     #[test]
     fn remove_exactly_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(25..75);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(25..=75);
         assert_eq!(range_map.to_vec(), vec![]);
     }
 
     #[test]
     fn remove_superset_of_stored() {
-        let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-        range_map.insert(25..75, false);
-        range_map.remove(0..100);
+        let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
+        range_map.insert(25..=75, false);
+        range_map.remove(0..=100);
         assert_eq!(range_map.to_vec(), vec![]);
+    }
+
+    //
+    // Test extremes of key ranges; we do addition/subtraction in
+    // the range domain so I want to make sure I haven't accidentally
+    // introduced some arithmetic overflow there.
+    //
+
+    #[test]
+    fn no_overflow_at_key_domain_extremes() {
+        let mut range_map: RangeInclusiveMap<u8, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=255, false);
+        range_map.insert(0..=10, true);
+        range_map.insert(245..=255, true);
+        range_map.remove(0..=5);
+        range_map.remove(0..=5);
+        range_map.remove(250..=255);
+        range_map.remove(250..=255);
+        range_map.insert(0..=255, true);
+        range_map.remove(1..=254);
     }
 }

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,0 +1,141 @@
+use std::ops::RangeInclusive;
+
+use crate::std_ext::*;
+use crate::RangeInclusiveMap;
+
+#[derive(Clone)]
+/// A set whose items are stored as ranges bounded
+/// inclusively below and above `(start..=end)`.
+///
+/// See [`RangeInclusiveMap`]'s documentation for more details.
+///
+/// [`RangeInclusiveMap`]: struct.RangeInclusiveMap.html
+pub struct RangeInclusiveSet<T, StepFnsT = T> {
+    rm: RangeInclusiveMap<T, (), StepFnsT>,
+}
+
+impl<T> Default for RangeInclusiveSet<T, T>
+where
+    T: Ord + Clone + StepLite,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> RangeInclusiveSet<T, T>
+where
+    T: Ord + Clone + StepLite,
+{
+    /// Makes a new empty `RangeInclusiveSet`.
+    pub fn new() -> Self {
+        Self::new_with_step_fns()
+    }
+}
+
+impl<T, StepFnsT> RangeInclusiveSet<T, StepFnsT>
+where
+    T: Ord + Clone,
+    StepFnsT: StepFns<T>,
+{
+    /// Makes a new empty `RangeInclusiveSet`, specifying successor and
+    /// predecessor functions defined separately from `T` itself.
+    ///
+    /// This is useful as a workaround for Rust's "orphan rules",
+    /// which prevent you from implementing `StepLite` for `T` if `T`
+    /// is a foreign type.
+    ///
+    /// **NOTE:** This will likely be deprecated and then eventually
+    /// removed once the standard library's [Step](std::iter::Step)
+    /// trait is stabilised, as most crates will then likely implement [Step](std::iter::Step)
+    /// for their types where appropriate.
+    ///
+    /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
+    /// for details about that stabilization process.
+    pub fn new_with_step_fns() -> Self {
+        Self {
+            rm: RangeInclusiveMap::new_with_step_fns(),
+        }
+    }
+
+    /// Returns a reference to the range covering the given key, if any.
+    pub fn get(&self, value: &T) -> Option<&RangeInclusive<T>> {
+        self.rm.get_key_value(value).map(|(range, _)| range)
+    }
+
+    /// Returns `true` if any range in the set covers the specified value.
+    pub fn contains(&self, value: &T) -> bool {
+        self.rm.contains_key(value)
+    }
+
+    /// Gets an ordered iterator over all ranges,
+    /// ordered by range.
+    pub fn iter(&self) -> impl Iterator<Item = &RangeInclusive<T>> {
+        self.rm.iter().map(|(range, _v)| range)
+    }
+
+    /// Insert a range into the set.
+    ///
+    /// If the inserted range either overlaps or is immediately adjacent
+    /// any existing range, then the ranges will be coalesced into
+    /// a single contiguous range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if range `start > end`.
+    pub fn insert(&mut self, range: RangeInclusive<T>) {
+        self.rm.insert(range, ());
+    }
+
+    /// Removes a range from the set, if all or any of it was present.
+    ///
+    /// If the range to be removed _partially_ overlaps any ranges
+    /// in the set, then those ranges will be contracted to no
+    /// longer cover the removed range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if range `start > end`.
+    pub fn remove(&mut self, range: RangeInclusive<T>) {
+        self.rm.remove(range);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    trait RangeInclusiveSetExt<T> {
+        fn to_vec(&self) -> Vec<RangeInclusive<T>>;
+    }
+
+    impl<T> RangeInclusiveSetExt<T> for RangeInclusiveSet<T>
+    where
+        T: Ord + Clone + StepLite,
+    {
+        fn to_vec(&self) -> Vec<RangeInclusive<T>> {
+            self.iter().cloned().collect()
+        }
+    }
+
+    #[test]
+    fn empty_set_is_empty() {
+        let range_set: RangeInclusiveSet<u32> = RangeInclusiveSet::new();
+        assert_eq!(range_set.to_vec(), vec![]);
+    }
+
+    #[test]
+    fn insert_into_empty_map() {
+        let mut range_set: RangeInclusiveSet<u32> = RangeInclusiveSet::new();
+        range_set.insert(0..=50);
+        assert_eq!(range_set.to_vec(), vec![0..=50]);
+    }
+
+    #[test]
+    fn remove_partially_overlapping() {
+        let mut range_set: RangeInclusiveSet<u32> = RangeInclusiveSet::new();
+        range_set.insert(0..=50);
+        range_set.remove(25..=75);
+        assert_eq!(range_set.to_vec(), vec![0..=24]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,14 @@
 /*!
-[RangeMap](struct.RangeMap.html) is a map data structure whose keys are
-stored as ranges. Contiguous and overlapping ranges
-that map to the same value are coalesced into a single range.
+[`RangeMap`] and [`RangeInclusiveMap`] are map data structures whose keys
+are stored as ranges. Contiguous and overlapping ranges that map to the same
+value are coalesced into a single range.
 
-A corresponding [RangeSet](struct.RangeSet.html) structure is also provided.
+Corresponding [`RangeSet`] and [`RangeInclusiveSet`] structures are also provided.
+
+[`RangeMap`]: crate::RangeMap
+[`RangeInclusiveMap`]: crate::RangeInclusiveMap
+[`RangeSet`]: crate::RangeSet
+[`RangeInclusiveSet`]: crate::RangeInclusiveSet
 
 
 # Example: use with Chrono

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ If the choice is not obvious in your case, consider these differences:
   as it does in the case of `f64`, on the specific value of `K`)
   from the end of the earlier range. (See the last point below for more
   on this problem.)
-- If you need to be able to represent ranges that _include_ every
-  point in the key domain (e.g. every value of `u8`) then you will
+- If you need to represent ranges that _include_ the maximum
+  value in the key domain (e.g. `255u8`) then you will
   probably want to use `RangeInclusive`s like `128u8..=255u8`. Sometimes
   it may be possible to instead work around this by using a wider key
   type than the values you are actually trying to represent (`K=u16`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,5 +61,5 @@ mod stupid_range_map;
 pub use inclusive_map::RangeInclusiveMap;
 pub use map::RangeMap;
 pub use set::RangeSet;
-pub use std_ext::StepLite;
+pub use std_ext::{StepFns, StepLite};
 // TODO: inclusive_set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,12 +49,17 @@ for (range, person) in roster.iter() {
 
 */
 
+mod inclusive_map;
 mod map;
 mod range_wrapper;
 mod set;
+// TODO: set_inclusive
 mod std_ext;
 #[cfg(test)]
 mod stupid_range_map;
 
+pub use inclusive_map::RangeInclusiveMap;
 pub use map::RangeMap;
 pub use set::RangeSet;
+pub use std_ext::StepLite;
+// TODO: inclusive_set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,43 @@ value are coalesced into a single range.
 
 Corresponding [`RangeSet`] and [`RangeInclusiveSet`] structures are also provided.
 
-[`RangeMap`]: crate::RangeMap
-[`RangeInclusiveMap`]: crate::RangeInclusiveMap
-[`RangeSet`]: crate::RangeSet
-[`RangeInclusiveSet`]: crate::RangeInclusiveSet
+
+# Different kinds of ranges
+
+`RangeMap` and `RangeInclusiveMap` correspond to the [`Range`]
+and [`RangeInclusive`] types from the standard library respectively.
+For some applications the choice of range type may be obvious,
+or even be dictated by pre-existing design decisions. For other applications
+the choice may seem arbitrary, and be guided instead by convenience or
+aesthetic preference.
+
+If the choice is not obvious in your case, consider these differences:
+
+- If your key type `K` represents points on a continuum (e.g. `f64`),
+  and the choice of which of two adjacent ranges "owns" the value
+  where they touch is largely arbitrary, then it may be more natural
+  to work with half-open `Range`s like `0.0..1.0` and `1.0..2.0`. If you
+  were to use closed `RangeInclusive`s here instead, then to represent two such adjacent
+  ranges you would need to subtract some infinitesimal (which may depend,
+  as it does in the case of `f64`, on the specific value of `K`)
+  from the end of the earlier range. (See the last point below for more
+  on this problem.)
+- If you need to be able to represent ranges that _include_ every
+  point in the key domain (e.g. every value of `u8`) then you will
+  probably want to use `RangeInclusive`s like `128u8..=255u8`. Sometimes
+  it may be possible to instead work around this by using a wider key
+  type than the values you are actually trying to represent (`K=u16`
+  even though you are only trying to represent ranges covering `u8`)
+  but in these cases the key domain often represents discrete objects
+  rather than points on a continuum, and so `RangeInclusive` may
+  be a more natural way to express these ranges anyway.
+- If you are using `RangeInclusive`, then it must be possible to define
+  _successor_ and _predecessor_ functions for your key type `K`,
+  because adjacent ranges can not be detected (and thereby coalesced)
+  simply by testing their ends for equality. For key types that represent
+  points on a continuum, defining these functions may be awkward and error-prone.
+  For key types that represent discrete objects, this is usually much
+  more straightforward.
 
 
 # Example: use with Chrono
@@ -51,6 +84,14 @@ for (range, person) in roster.iter() {
 // 2019-02-25UTC (P7D): Bob
 // 2019-03-04UTC (P7D): Carol
 ```
+
+
+[`RangeMap`]: crate::RangeMap
+[`RangeInclusiveMap`]: crate::RangeInclusiveMap
+[`RangeSet`]: crate::RangeSet
+[`RangeInclusiveSet`]: crate::RangeInclusiveSet
+[`Range`]: std::ops::Range
+[`RangeInclusive`]: std::ops::RangeInclusive
 
 */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,16 +50,16 @@ for (range, person) in roster.iter() {
 */
 
 mod inclusive_map;
+mod inclusive_set;
 mod map;
 mod range_wrapper;
 mod set;
-// TODO: set_inclusive
 mod std_ext;
 #[cfg(test)]
 mod stupid_range_map;
 
 pub use inclusive_map::RangeInclusiveMap;
+pub use inclusive_set::RangeInclusiveSet;
 pub use map::RangeMap;
 pub use set::RangeSet;
 pub use std_ext::{StepFns, StepLite};
-// TODO: inclusive_set

--- a/src/map.rs
+++ b/src/map.rs
@@ -159,6 +159,11 @@ where
             if stored_range_start_wrapper.range.start == new_range_start_wrapper.range.end
                 && *stored_value != new_value
             {
+                // We're beyond the last stored range that could be relevant.
+                // Avoid wasting time on irrelevant ranges, or even worse, looping forever.
+                // (`adjust_touching_ranges_for_insert` below assumes that the given range
+                // is relevant, and behaves very poorly if it is handed a range that it
+                // shouldn't be touching.)
                 break;
             }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,11 +3,12 @@ use crate::std_ext::*;
 use std::collections::BTreeMap;
 use std::ops::Range;
 
-#[derive(Clone)]
-/// A map whose keys are stored as (half-open) ranges.
+/// A map whose keys are stored as (half-open) ranges bounded
+/// inclusively below and exclusively above `(start..end)`.
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
+#[derive(Clone)]
 pub struct RangeMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.

--- a/src/map.rs
+++ b/src/map.rs
@@ -56,10 +56,7 @@ where
             .filter(|(range_start_wrapper, _value)| {
                 // Does the only candidate range contain
                 // the requested key?
-                //
-                // TODO: Use `contains` once https://github.com/rust-lang/rust/issues/32311
-                // is stabilized.
-                range_start_wrapper.range.contains_item(key)
+                range_start_wrapper.range.contains(key)
             })
             .map(|(range_start_wrapper, value)| (&range_start_wrapper.range, value))
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -517,6 +517,9 @@ mod tests {
             for (k, v) in permutation {
                 // Insert it into both maps.
                 range_map.insert(k.clone(), v);
+                // NOTE: Clippy's `range_minus_one` lint is a bit overzealous here,
+                // because we _can't_ pass an open-ended range to `insert`.
+                #[allow(clippy::range_minus_one)]
                 stupid.insert(k.start..=(k.end - 1), v);
 
                 // At every step, both maps should contain the same stuff.

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -1,4 +1,4 @@
-// Wrapper to allow storing (and sorting/searching)
+// Wrappers to allow storing (and sorting/searching)
 // ranges as the keys of a `BTreeMap`.
 //
 // We can do this because we maintain the invariants
@@ -11,46 +11,88 @@
 // inner range!
 
 use std::cmp::Ordering;
-use std::ops::Range;
+use std::ops::{Range, RangeInclusive};
 
 //
 // Range start wrapper
 //
 
 #[derive(Eq, Debug, Clone)]
-pub struct StartWrapper<T> {
+pub struct RangeStartWrapper<T> {
     pub range: Range<T>,
 }
 
-impl<T> StartWrapper<T> {
-    pub fn new(range: Range<T>) -> StartWrapper<T> {
-        StartWrapper { range }
+impl<T> RangeStartWrapper<T> {
+    pub fn new(range: Range<T>) -> RangeStartWrapper<T> {
+        RangeStartWrapper { range }
     }
 }
 
-impl<T> PartialEq for StartWrapper<T>
+impl<T> PartialEq for RangeStartWrapper<T>
 where
     T: Eq,
 {
-    fn eq(&self, other: &StartWrapper<T>) -> bool {
+    fn eq(&self, other: &RangeStartWrapper<T>) -> bool {
         self.range.start == other.range.start
     }
 }
 
-impl<T> Ord for StartWrapper<T>
+impl<T> Ord for RangeStartWrapper<T>
 where
     T: Ord,
 {
-    fn cmp(&self, other: &StartWrapper<T>) -> Ordering {
+    fn cmp(&self, other: &RangeStartWrapper<T>) -> Ordering {
         self.range.start.cmp(&other.range.start)
     }
 }
 
-impl<T> PartialOrd for StartWrapper<T>
+impl<T> PartialOrd for RangeStartWrapper<T>
 where
     T: Ord,
 {
-    fn partial_cmp(&self, other: &StartWrapper<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &RangeStartWrapper<T>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+//
+// RangeInclusive start wrapper
+//
+
+#[derive(Eq, Debug, Clone)]
+pub struct RangeInclusiveStartWrapper<T> {
+    pub range: RangeInclusive<T>,
+}
+
+impl<T> RangeInclusiveStartWrapper<T> {
+    pub fn new(range: RangeInclusive<T>) -> RangeInclusiveStartWrapper<T> {
+        RangeInclusiveStartWrapper { range }
+    }
+}
+
+impl<T> PartialEq for RangeInclusiveStartWrapper<T>
+where
+    T: Eq,
+{
+    fn eq(&self, other: &RangeInclusiveStartWrapper<T>) -> bool {
+        self.range.start() == other.range.start()
+    }
+}
+
+impl<T> Ord for RangeInclusiveStartWrapper<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Ordering {
+        self.range.start().cmp(&other.range.start())
+    }
+}
+
+impl<T> PartialOrd for RangeInclusiveStartWrapper<T>
+where
+    T: Ord,
+{
+    fn partial_cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,7 +3,8 @@ use std::ops::Range;
 use crate::RangeMap;
 
 #[derive(Clone)]
-/// A set whose items are stored as ranges.
+/// A set whose items are stored as (half-open) ranges bounded
+/// inclusively below and exclusively above `(start..end)`.
 ///
 /// See [`RangeMap`]'s documentation for more details.
 ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -80,11 +80,11 @@ where
 mod tests {
     use super::*;
 
-    trait RangeMapExt<T> {
+    trait RangeSetExt<T> {
         fn to_vec(&self) -> Vec<Range<T>>;
     }
 
-    impl<T> RangeMapExt<T> for RangeSet<T>
+    impl<T> RangeSetExt<T> for RangeSet<T>
     where
         T: Ord + Clone,
     {

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -1,4 +1,5 @@
-use std::ops::Range;
+use num::Bounded;
+use std::ops::{Range, RangeInclusive};
 
 pub trait RangeExt<T> {
     fn overlaps(&self, other: &Self) -> bool;
@@ -32,3 +33,99 @@ where
         *item >= self.start && *item < self.end
     }
 }
+
+pub trait RangeInclusiveExt<T> {
+    fn overlaps(&self, other: &Self) -> bool;
+    fn touches(&self, other: &Self) -> bool
+    where
+        T: StepLite + Bounded + Clone;
+    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
+    // is stabilized.
+    fn contains_item(&self, item: &T) -> bool;
+}
+
+impl<T> RangeInclusiveExt<T> for RangeInclusive<T>
+where
+    T: Ord,
+{
+    fn overlaps(&self, other: &Self) -> bool {
+        use std::cmp::{max, min};
+        // Less than or equal, because ends are included.
+        max(self.start(), other.start()) <= min(self.end(), other.end())
+    }
+
+    fn touches(&self, other: &Self) -> bool
+    where
+        T: StepLite + Bounded + Clone,
+    {
+        use std::cmp::{max, min};
+        // Touching for end-inclusive ranges is equivalent to touching of
+        // slightly longer end-inclusive ranges.
+        //
+        // We need to do this dance to avoid arithmetic overflow
+        // at the extremes of the key space.
+        let longer_self_end: T = if *self.end() == T::max_value() {
+            (*self.end()).clone()
+        } else {
+            self.end().add_one()
+        };
+        let longer_other_end: T = if *other.end() == T::max_value() {
+            other.end().clone()
+        } else {
+            other.end().add_one()
+        };
+        max(self.start(), other.start()) <= min(&longer_self_end, &longer_other_end)
+    }
+
+    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
+    // is stabilized.
+    fn contains_item(&self, item: &T) -> bool {
+        *item >= *self.start() && *item <= *self.end()
+    }
+}
+
+/// Minimal version of unstable [Step](std::iter::Step) trait
+/// from the Rust standard library.
+///
+/// This is needed for [RangeInclusiveMap](crate::RangeInclusiveMap)
+/// because ranges stored as its keys interact with each other
+/// when the start of one is _adjacent_ the end of another.
+/// I.e. we need a concept of successor values rather than just
+/// equality, and that is what [Step](std::iter::Step) will
+/// eventually provide once it is stabilized.
+//
+// TODO: Deprecate and then eventually remove once
+// https://github.com/rust-lang/rust/issues/42168 is stabilized.
+pub trait StepLite {
+    fn add_one(&self) -> Self;
+    fn sub_one(&self) -> Self;
+}
+
+// Makes tests work.
+impl StepLite for u32 {
+    fn add_one(&self) -> Self {
+        self + 1
+    }
+
+    fn sub_one(&self) -> Self {
+        self - 1
+    }
+}
+
+impl StepLite for u8 {
+    fn add_one(&self) -> Self {
+        self + 1
+    }
+
+    fn sub_one(&self) -> Self {
+        self - 1
+    }
+}
+
+// TODO: Auto-implement for all common types?
+// But people will still need to implement it for
+// their own types, so need to find the least painful
+// way for consumers.
+
+// TODO: When on nightly, a blanket implementation for
+// all types that implement `std::iter::Step`.

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -4,9 +4,6 @@ use std::ops::{Range, RangeInclusive};
 pub trait RangeExt<T> {
     fn overlaps(&self, other: &Self) -> bool;
     fn touches(&self, other: &Self) -> bool;
-    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
-    // is stabilized.
-    fn contains_item(&self, item: &T) -> bool;
 }
 
 impl<T> RangeExt<T> for Range<T>
@@ -26,12 +23,6 @@ where
         // or immediately adjacent.
         max(&self.start, &other.start) <= min(&self.end, &other.end)
     }
-
-    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
-    // is stabilized.
-    fn contains_item(&self, item: &T) -> bool {
-        *item >= self.start && *item < self.end
-    }
 }
 
 pub trait RangeInclusiveExt<T> {
@@ -39,9 +30,6 @@ pub trait RangeInclusiveExt<T> {
     fn touches(&self, other: &Self) -> bool
     where
         T: StepLite + Bounded + Clone;
-    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
-    // is stabilized.
-    fn contains_item(&self, item: &T) -> bool;
 }
 
 impl<T> RangeInclusiveExt<T> for RangeInclusive<T>
@@ -75,12 +63,6 @@ where
             other.end().add_one()
         };
         max(self.start(), other.start()) <= min(&longer_self_end, &longer_other_end)
-    }
-
-    // TODO: Remove once https://github.com/rust-lang/rust/issues/32311
-    // is stabilized.
-    fn contains_item(&self, item: &T) -> bool {
-        *item >= *self.start() && *item <= *self.end()
     }
 }
 

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -67,19 +67,19 @@ where
     }
 }
 
-/// Minimal version of unstable [Step](std::iter::Step) trait
+/// Minimal version of unstable [`Step`](std::iter::Step) trait
 /// from the Rust standard library.
 ///
-/// This is needed for [RangeInclusiveMap](crate::RangeInclusiveMap)
+/// This is needed for [`RangeInclusiveMap`](crate::RangeInclusiveMap)
 /// because ranges stored as its keys interact with each other
 /// when the start of one is _adjacent_ the end of another.
 /// I.e. we need a concept of successor values rather than just
-/// equality, and that is what [Step](std::iter::Step) will
+/// equality, and that is what `Step` will
 /// eventually provide once it is stabilized.
 ///
 /// **NOTE:** This will likely be deprecated and then eventually
-/// removed once the standard library's [Step](std::iter::Step)
-/// trait is stabilised, as most crates will then likely implement [Step](std::iter::Step)
+/// removed once the standard library's `Step`
+/// trait is stabilised, as most crates will then likely implement `Step`
 /// for their types where appropriate.
 ///
 /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
@@ -118,12 +118,12 @@ impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 /// but as free functions rather than methods on `T` itself.
 ///
 /// This is useful as a workaround for Rust's "orphan rules",
-/// which prevent you from implementing `StepLite` for `T` if `T`
+/// which prevent you from implementing [`StepLite`](crate::StepLite) for `T` if `T`
 /// is a foreign type.
 ///
 /// **NOTE:** This will likely be deprecated and then eventually
-/// removed once the standard library's [Step](std::iter::Step)
-/// trait is stabilised, as most crates will then likely implement [Step](std::iter::Step)
+/// removed once the standard library's [`Step`](std::iter::Step)
+/// trait is stabilised, as most crates will then likely implement `Step`
 /// for their types where appropriate.
 ///
 /// See [this issue](https://github.com/rust-lang/rust/issues/42168)

--- a/src/stupid_range_map.rs
+++ b/src/stupid_range_map.rs
@@ -47,6 +47,10 @@ where
             // Convert to inclusive end.
             // (This is only valid because u32 has
             // the "successor function".)
+            //
+            // NOTE: Clippy's `range_minus_one` lint is a bit overzealous here,
+            // because we _can't_ pass an open-ended range to `insert`.
+            #[allow(clippy::range_minus_one)]
             stupid.insert(range.start..=(range.end - 1), value.clone());
         }
         stupid

--- a/src/stupid_range_map.rs
+++ b/src/stupid_range_map.rs
@@ -61,7 +61,7 @@ impl<V> From<RangeInclusiveMap<u32, V>> for StupidU32RangeMap<V>
 where
     V: Eq + Clone,
 {
-    fn from(range_inclusive_map: RangeInclusiveMap<u32, V>) -> Self {
+    fn from(range_inclusive_map: RangeInclusiveMap<u32, V, u32>) -> Self {
         let mut stupid = Self::new();
         for (range, value) in range_inclusive_map.iter() {
             stupid.insert(range.clone(), value.clone());

--- a/src/stupid_range_map.rs
+++ b/src/stupid_range_map.rs
@@ -1,14 +1,18 @@
 use std::collections::BTreeMap;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
-use super::RangeMap;
+use super::{RangeInclusiveMap, RangeMap};
 
 // A simple but infeasibly slow and memory-hungry
-// version of `RangeMap` for testing.
+// version of `RangeInclusiveMap` for testing.
 //
 // Only understands `u32` keys, so that we don't
 // have to be generic over `step`. This is just for
 // testing, so it's fine.
+//
+// Note that even though this mirrors the semantics
+// of `RangeInclusiveMap`, it can also be used to
+// test `RangeMap` just fine.
 #[derive(Eq, PartialEq, Debug)]
 pub struct StupidU32RangeMap<V> {
     // Inner B-Tree map. Stores values and their keys
@@ -26,7 +30,7 @@ where
         }
     }
 
-    pub fn insert(&mut self, range: Range<u32>, value: V) {
+    pub fn insert(&mut self, range: RangeInclusive<u32>, value: V) {
         for k in range {
             self.btm.insert(k, value.clone());
         }
@@ -40,6 +44,22 @@ where
     fn from(range_map: RangeMap<u32, V>) -> Self {
         let mut stupid = Self::new();
         for (range, value) in range_map.iter() {
+            // Convert to inclusive end.
+            // (This is only valid because u32 has
+            // the "successor function".)
+            stupid.insert(range.start..=(range.end - 1), value.clone());
+        }
+        stupid
+    }
+}
+
+impl<V> From<RangeInclusiveMap<u32, V>> for StupidU32RangeMap<V>
+where
+    V: Eq + Clone,
+{
+    fn from(range_inclusive_map: RangeInclusiveMap<u32, V>) -> Self {
+        let mut stupid = Self::new();
+        for (range, value) in range_inclusive_map.iter() {
             stupid.insert(range.clone(), value.clone());
         }
         stupid


### PR DESCRIPTION
Uses RangeInclusive instead of Range as its keys.

This requires a bit of fiddling around with extra trait bounds
on the keys, because ranges can interact with each other by having
one range's start exactly one away from another range's end.

This requires use of the unstable Step trait (or some equivalent,
which I've introduced here) _and_ the ability to know the max
value of the key space, which I'm achieving using `num` for now.

The latter may be possible to relax with some different trickery
around the order of ranges we're comparing, and a different way
of short-circuiting some loops. I'm going to experiment with that
before committing to bringing in any extra dependency.

## TODO

- [x] Remove need for `num` crate
    - [x] Replace use in `std_ext` with understanding of which range comes first. (A bit fiddly, but better than needing to guard against max val.)
    - [x] Replace use in `inclusive_map` with a different way to short-circuit loop once you find a range greater than what you're interested in.
- [x] Add `RangeInclusiveSet` type
- [ ] Auto-implement `StepLite` for all the common types people might want
    - [x] Implement for all standard integer types
    - [ ] [LATER] 'unstable' feature to add blanket impl for everything that implements `Step` from std
    - [ ] [LATER] Optional features for types in common crates? Probably not worth it...
- [x] Document `StepLite` and its need thoroughly, with advice on how to implement it for your own types.
- [x] Document example use cases for `RangeMap` and `RangeInclusiveMap` in case the distinction between `Range` and `RangeInclusive` isn't already well-understood by consumers.