### PR TITLE
Add `gaps` iterator for all map and set types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### vNEXT (unreleased)
 
-...
-
+- **Features**:
+    - Add `gaps` method to all map and set types for iterating over sub-ranges of a given outer range that are not covered by any stored range.
 
 ### v0.1.6 (2020-07-15)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,20 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-skeptic = { version = "0.13", optional = true }
+# Upstream skeptic is broken on stable.
+# See <https://github.com/budziq/rust-skeptic/pull/121#issuecomment-668634236>
+# and linked issue.
+skeptic = { git = 'https://github.com/andygauge/rust-skeptic', optional = true }
 
 [dev-dependencies]
 permutator = "0.3"
 criterion = "0.2"
 rand = "0.6"
 chrono = "0.4" # For examples
-skeptic = "0.13"
+# Upstream skeptic is broken on stable.
+# See <https://github.com/budziq/rust-skeptic/pull/121#issuecomment-668634236>
+# and linked issue.
+skeptic = { git = 'https://github.com/andygauge/rust-skeptic'}
 
 [features]
 # Skeptic is only needed for doc generation.

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -18,7 +18,7 @@ use std::ops::RangeInclusive;
 /// You can provide these functions either by implementing the
 /// [`StepLite`](crate::StepLite) trait for your key type `K`, or,
 /// if this is impossible because of Rust's "orphan rules",
-/// you can provide equivalent free functions using the `StepsFnsT` type parameter.
+/// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
 #[derive(Clone)]

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -410,6 +410,136 @@ where
             );
         }
     }
+
+    /// Gets an iterator over all the maximally-sized ranges
+    /// contained in `outer_range` that are not covered by
+    /// any range stored in the map.
+    ///
+    /// The iterator element type is `RangeInclusive<K>`.
+    ///
+    /// NOTE: Calling `gaps` eagerly finds the first gap,
+    /// even if the iterator is never consumed.
+    pub fn gaps<'a>(&'a self, outer_range: &'a RangeInclusive<K>) -> Gaps<'a, K, V, StepFnsT> {
+        let mut keys = self.btm.keys().peekable();
+
+        // Find the first potential gap.
+        let mut candidate_start = outer_range.start().clone();
+        // We might be already done from the start,
+        // but not be able to represent it using
+        // `candidate_start` alone if we're at the end
+        // of the key domain.
+        let mut done = false;
+        while let Some(item) = keys.peek() {
+            if item.range.end() < outer_range.start() {
+                // This range sits entirely before the start of
+                // the outer range; just skip it.
+                let _ = keys.next();
+            } else if item.range.start() <= outer_range.start() {
+                // This range overlaps the start of the
+                // outer range, so the first possible candidate
+                // range begins immediately after its end.
+                if item.range.end() >= outer_range.end() {
+                    // There's a risk of overflowing;
+                    // use our extra "done" flag to represent
+                    // that the iterator is already done.
+                    // (Don't worry about `candidate_start`
+                    // we'll ignore everything else if `done`
+                    // is `true`.)
+                    done = true;
+                } else {
+                    candidate_start = StepFnsT::add_one(item.range.end());
+                }
+                let _ = keys.next();
+            } else {
+                // The rest of the items might contribute to gaps.
+                break;
+            }
+        }
+
+        Gaps {
+            done,
+            outer_range,
+            keys,
+            candidate_start,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub struct Gaps<'a, K, V, StepFnsT> {
+    /// Would be redundant, but we need an extra flag to
+    /// avoid overflowing when dealing with inclusive ranges.
+    ///
+    /// All other things here are ignored if `done` is `true`.
+    done: bool,
+    outer_range: &'a RangeInclusive<K>,
+    keys: std::iter::Peekable<
+        std::collections::btree_map::Keys<'a, RangeInclusiveStartWrapper<K>, V>,
+    >,
+    candidate_start: K,
+    _phantom: PhantomData<StepFnsT>,
+}
+
+// `Gaps` is always fused. (See definition of `next` below.)
+impl<'a, K, V, StepFnsT> std::iter::FusedIterator for Gaps<'a, K, V, StepFnsT>
+where
+    K: Ord + Clone,
+    StepFnsT: StepFns<K>,
+{
+}
+
+impl<'a, K, V, StepFnsT> Iterator for Gaps<'a, K, V, StepFnsT>
+where
+    K: Ord + Clone,
+    StepFnsT: StepFns<K>,
+{
+    type Item = RangeInclusive<K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done || self.candidate_start > *self.outer_range.end() {
+            // We've already passed the end of the outer range;
+            // there are no more gaps to find.
+            return None;
+        }
+
+        // Figure out where this gap ends.
+        let (end, next_candidate_start) = if let Some(item) = self.keys.next() {
+            if item.range.start() <= self.outer_range.end() {
+                // The gap goes up until just before the start of the next item,
+                // and the next candidate starts after it.
+                (
+                    StepFnsT::sub_one(item.range.start()),
+                    StepFnsT::add_one(item.range.end()),
+                )
+            } else {
+                // The item sits after the end of the outer range,
+                // so this gap ends at the end of the outer range.
+                // This also means there will be no more gaps.
+                self.done = true;
+                (
+                    self.outer_range.end().clone(),
+                    // This value will be ignored.
+                    self.candidate_start.clone(),
+                )
+            }
+        } else {
+            // There's no next item; the end is at the
+            // end of the outer range.
+            // This also means there will be no more gaps.
+            self.done = true;
+            (
+                self.outer_range.end().clone(),
+                // This value will be ignored.
+                self.candidate_start.clone(),
+            )
+        };
+
+        // Move the next candidate gap start past the end
+        // of this gap, and yield the gap we found.
+        let gap = self.candidate_start.clone()..=end.clone();
+        self.candidate_start = next_candidate_start;
+        Some(gap)
+    }
 }
 
 #[cfg(test)]
@@ -715,5 +845,296 @@ mod tests {
         range_map.insert(0..=0, false);
         range_map.insert(1..=1, true);
         range_map.insert(0..=0, true);
+    }
+
+    // Gaps tests
+
+    #[test]
+    fn whole_range_is_a_gap() {
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        let range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-------------◆ ◌
+        let outer_range = 1..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn whole_range_is_covered_exactly() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●---------● ◌ ◌ ◌
+        range_map.insert(1..=6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---------◆ ◌ ◌ ◌
+        let outer_range = 1..=6;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_before_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●---● ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=3, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◆ ◌
+        let outer_range = 5..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(5..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_touching_start_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-----● ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◆ ◌
+        let outer_range = 5..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(5..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_overlapping_start_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-------● ◌ ◌ ◌ ◌
+        range_map.insert(1..=5, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◆ ◌
+        let outer_range = 5..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from just past the end of the stored item
+        // to the end of the outer range.
+        assert_eq!(gaps.next(), Some(6..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_starting_at_start_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ●-● ◌ ◌ ◌
+        range_map.insert(5..=6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◆ ◌
+        let outer_range = 5..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from just past the item onwards.
+        assert_eq!(gaps.next(), Some(7..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn items_floating_inside_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●-● ◌ ◌
+        range_map.insert(6..=7, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ●-● ◌ ◌ ◌ ◌ ◌
+        range_map.insert(3..=4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-------------◆ ◌
+        let outer_range = 1..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield gaps at start, between items,
+        // and at end.
+        assert_eq!(gaps.next(), Some(1..=2));
+        assert_eq!(gaps.next(), Some(5..=5));
+        assert_eq!(gaps.next(), Some(8..=8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_ending_at_end_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ◌ ●-● ◌
+        range_map.insert(7..=8, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◆ ◌
+        let outer_range = 5..=8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the start of the outer range
+        // up to just before the start of the stored item.
+        assert_eq!(gaps.next(), Some(5..=6));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_overlapping_end_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ●---● ◌ ◌
+        range_map.insert(5..=6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-----◆ ◌ ◌ ◌ ◌
+        let outer_range = 2..=5;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the start of the outer range
+        // up to the start of the stored item.
+        assert_eq!(gaps.next(), Some(2..=4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_touching_end_of_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ●-----● ◌
+        range_map.insert(5..=9, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-----◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 1..=4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..=4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_after_outer_range() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●---● ◌
+        range_map.insert(6..=7, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-----◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 1..=4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..=4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn zero_width_outer_range_with_items_away_from_both_sides() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---◆ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..=3, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆---◆ ◌ ◌
+        range_map.insert(5..=7, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..=4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield a zero-width gap.
+        assert_eq!(gaps.next(), Some(4..=4));
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn zero_width_outer_range_with_items_touching_both_sides() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-◆ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..=3, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆---◆ ◌ ◌ ◌
+        range_map.insert(5..=6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..=4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), Some(4..=4));
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn empty_outer_range_with_item_straddling() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-----◆ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..=5, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..=4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn no_overflow_finding_gaps_at_key_domain_extremes() {
+        // Items and outer range both at extremes.
+        let mut range_map: RangeInclusiveMap<u8, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=255, false);
+        range_map.gaps(&(0..=255));
+
+        // Items at extremes with gaps in middle.
+        let mut range_map: RangeInclusiveMap<u8, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=255, false);
+        range_map.gaps(&(0..=5));
+        range_map.gaps(&(250..=255));
+
+        // Items just in from extremes.
+        let mut range_map: RangeInclusiveMap<u8, bool> = RangeInclusiveMap::new();
+        range_map.insert(0..=255, false);
+        range_map.gaps(&(1..=5));
+        range_map.gaps(&(250..=254));
+
+        // Outer range just in from extremes,
+        // items at extremes.
+        let mut range_map: RangeInclusiveMap<u8, bool> = RangeInclusiveMap::new();
+        range_map.insert(1..=254, false);
+        range_map.gaps(&(0..=5));
+        range_map.gaps(&(250..=255));
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -333,6 +333,92 @@ where
             );
         }
     }
+
+    /// Gets an iterator over all the maximally-sized ranges
+    /// contained in `outer_range` that are not covered by
+    /// any range stored in the map.
+    ///
+    /// The iterator element type is `Range<K>`.
+    ///
+    /// NOTE: Calling `gaps` eagerly finds the first gap,
+    /// even if the iterator is never consumed.
+    pub fn gaps<'a>(&'a self, outer_range: &'a Range<K>) -> Gaps<'a, K, V> {
+        let mut keys = self.btm.keys().peekable();
+
+        // Find the first potential gap.
+        let mut candidate_start = &outer_range.start;
+        while let Some(item) = keys.peek() {
+            if item.range.end <= outer_range.start {
+                // This range sits entirely before the start of
+                // the outer range; just skip it.
+                let _ = keys.next();
+            } else if item.range.start <= outer_range.start {
+                // This range overlaps the start of the
+                // outer range, so the first possible candidate
+                // range begins at its end.
+                candidate_start = &item.range.end;
+                let _ = keys.next();
+            } else {
+                // The rest of the items might contribute to gaps.
+                break;
+            }
+        }
+
+        Gaps {
+            outer_range,
+            keys,
+            candidate_start,
+        }
+    }
+}
+
+pub struct Gaps<'a, K, V> {
+    outer_range: &'a Range<K>,
+    keys: std::iter::Peekable<std::collections::btree_map::Keys<'a, RangeStartWrapper<K>, V>>,
+    candidate_start: &'a K,
+}
+
+// `Gaps` is always fused. (See definition of `next` below.)
+impl<'a, K, V> std::iter::FusedIterator for Gaps<'a, K, V> where K: Ord + Clone {}
+
+impl<'a, K, V> Iterator for Gaps<'a, K, V>
+where
+    K: Ord + Clone,
+{
+    type Item = Range<K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if *self.candidate_start >= self.outer_range.end {
+            // We've already passed the end of the outer range;
+            // there are no more gaps to find.
+            return None;
+        }
+
+        // Figure out where this gap ends.
+        let (end, next_candidate_start) = if let Some(item) = self.keys.next() {
+            if item.range.start < self.outer_range.end {
+                // The gap goes up until the start of the next item,
+                // and the next candidate starts after it.
+                (&item.range.start, &item.range.end)
+            } else {
+                // The item sits after the end of the outer range,
+                // so this gap ends at the end of the outer range.
+                // This also means there will be no more gaps.
+                (&self.outer_range.end, &self.outer_range.end)
+            }
+        } else {
+            // There's no next item; the end is at the
+            // end of the outer range.
+            // This also means there will be no more gaps.
+            (&self.outer_range.end, &self.outer_range.end)
+        };
+
+        // Move the next candidate gap start past the end
+        // of this gap, and yield the gap we found.
+        let gap = self.candidate_start.clone()..end.clone();
+        self.candidate_start = next_candidate_start;
+        Some(gap)
+    }
 }
 
 #[cfg(test)]
@@ -615,5 +701,269 @@ mod tests {
         range_map.insert(25..75, false);
         range_map.remove(0..100);
         assert_eq!(range_map.to_vec(), vec![]);
+    }
+
+    // Gaps tests
+
+    #[test]
+    fn whole_range_is_a_gap() {
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        let range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-------------◇ ◌
+        let outer_range = 1..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn whole_range_is_covered_exactly() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●---------◌ ◌ ◌ ◌
+        range_map.insert(1..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---------◇ ◌ ◌ ◌
+        let outer_range = 1..6;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_before_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●---◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..3, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◇ ◌
+        let outer_range = 5..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(5..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_touching_start_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●-------◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..5, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◇ ◌
+        let outer_range = 5..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(5..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_overlapping_start_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ●---------◌ ◌ ◌ ◌
+        range_map.insert(1..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◇ ◌
+        let outer_range = 5..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the end of the stored item
+        // to the end of the outer range.
+        assert_eq!(gaps.next(), Some(6..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_starting_at_start_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ●-◌ ◌ ◌ ◌
+        range_map.insert(5..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◇ ◌
+        let outer_range = 5..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the item onwards.
+        assert_eq!(gaps.next(), Some(6..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn items_floating_inside_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ●-◌ ◌ ◌ ◌
+        range_map.insert(5..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ●-◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(3..4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-------------◇ ◌
+        let outer_range = 1..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield gaps at start, between items,
+        // and at end.
+        assert_eq!(gaps.next(), Some(1..3));
+        assert_eq!(gaps.next(), Some(4..5));
+        assert_eq!(gaps.next(), Some(6..8));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_ending_at_end_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ◌ ●-◌ ◌
+        range_map.insert(7..8, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆-----◇ ◌
+        let outer_range = 5..8;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the start of the outer range
+        // up to the start of the stored item.
+        assert_eq!(gaps.next(), Some(5..7));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_overlapping_end_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ●---◌ ◌ ◌ ◌
+        range_map.insert(4..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-----◇ ◌ ◌ ◌ ◌
+        let outer_range = 2..5;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield from the start of the outer range
+        // up to the start of the stored item.
+        assert_eq!(gaps.next(), Some(2..4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_touching_end_of_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ●-------◌ ◌
+        range_map.insert(4..8, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-----◇ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 1..4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn item_after_outer_range() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●---◌ ◌
+        range_map.insert(6..7, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-----◇ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 1..4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield the entire outer range.
+        assert_eq!(gaps.next(), Some(1..4));
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn empty_outer_range_with_items_away_from_both_sides() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---◇ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(1..3, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◆---◇ ◌ ◌
+        range_map.insert(5..7, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn empty_outer_range_with_items_touching_both_sides() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆---◇ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆---◇ ◌ ◌ ◌
+        range_map.insert(4..6, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn empty_outer_range_with_item_straddling() {
+        let mut range_map: RangeMap<u32, ()> = RangeMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-----◇ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(2..5, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◆ ◌ ◌ ◌ ◌ ◌
+        let outer_range = 4..4;
+        let mut gaps = range_map.gaps(&outer_range);
+        // Should yield no gaps.
+        assert_eq!(gaps.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(gaps.next(), None);
+        assert_eq!(gaps.next(), None);
     }
 }


### PR DESCRIPTION
Allows iterating over all sub-ranges of a given outer range that are not
covered by stored ranges.