### PR TITLE
Add Debug to publicly exported types

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -21,7 +21,7 @@ use std::ops::RangeInclusive;
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RangeInclusiveMap<K, V, StepFnsT = K> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
@@ -466,6 +466,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Gaps<'a, K, V, StepFnsT> {
     /// Would be redundant, but we need an extra flag to
     /// avoid overflowing when dealing with inclusive ranges.

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
@@ -115,6 +115,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Gaps<'a, T, StepFnsT> {
     inner: crate::inclusive_map::Gaps<'a, T, (), StepFnsT>,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RangeMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
@@ -372,6 +372,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Gaps<'a, K, V> {
     outer_range: &'a Range<K>,
     keys: std::iter::Peekable<std::collections::btree_map::Keys<'a, RangeStartWrapper<K>, V>>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use crate::RangeMap;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
@@ -90,6 +90,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct Gaps<'a, T> {
     inner: crate::map::Gaps<'a, T, ()>,
 }


### PR DESCRIPTION
Thank you for making rangemap. 

I've been using this library in a project, and I noticed that some of the publicly exported types were lacking the `#[derive(Debug)]` attribute. This forces me to implement `Debug` manually for types that use `rangemap`, which I find inconvenient.

This PR adds `#[derive(Debug)]` to all publicly exported types (namely `RangeMap`, `RangeSet`, their `Inclusive` variants) and the `Gaps` structs as well (which I'm unsure if they are exported).