### PR TITLE
Fix a performance regression in 0.1.9.

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -158,6 +158,8 @@ where
         let mut candidates = self
             .btm
             .range((Bound::Unbounded, Bound::Included(&new_range_start_wrapper)))
+            .rev()
+            .take(2)
             .filter(|(stored_range_start_wrapper, _stored_value)| {
                 // Does the candidate range either overlap
                 // or immediately precede the range to insert?
@@ -167,9 +169,9 @@ where
                     .range
                     .touches::<StepFnsT>(&new_range_start_wrapper.range)
             });
-        if let Some(mut candidate) = candidates.next_back() {
+        if let Some(mut candidate) = candidates.next() {
             // Or the one before it if both cases described above exist.
-            if let Some(another_candidate) = candidates.next_back() {
+            if let Some(another_candidate) = candidates.next() {
                 candidate = another_candidate;
             }
             let (stored_range_start_wrapper, stored_value) =

--- a/src/map.rs
+++ b/src/map.rs
@@ -111,6 +111,8 @@ where
         let mut candidates = self
             .btm
             .range((Bound::Unbounded, Bound::Included(&new_range_start_wrapper)))
+            .rev()
+            .take(2)
             .filter(|(stored_range_start_wrapper, _stored_value)| {
                 // Does the candidate range either overlap
                 // or immediately precede the range to insert?
@@ -120,9 +122,9 @@ where
                     .range
                     .touches(&new_range_start_wrapper.range)
             });
-        if let Some(mut candidate) = candidates.next_back() {
+        if let Some(mut candidate) = candidates.next() {
             // Or the one before it if both cases described above exist.
-            if let Some(another_candidate) = candidates.next_back() {
+            if let Some(another_candidate) = candidates.next() {
                 candidate = another_candidate;
             }
             let (stored_range_start_wrapper, stored_value) =


### PR DESCRIPTION
This performance issue stems from the fix for #24 in d1999f4.
Previously, when the code was looking for "touching" ranges, it
applies the filter() block to at most one range (from next_back()).
But with the change in d1999f4, if none of the ranges pass the
filter, the code now potentially looks at a large number of ranges,
making insert() potentially quadratic in the map size (I think).

This patch fixes the issue by applying the "filter" to
".rev().take(2)" -- at most the two final ranges that could match.
This way, neither of the last two ranges are touching the
just-inserted range, then no more ranges are considered.

(I have verified that the tests and fuzzers still pass with this
change, but I do not know the code well enough to promise it is
correct.)