### PR TITLE
Add no_std support

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1,9 +1,10 @@
 use super::range_wrapper::RangeInclusiveStartWrapper;
 use crate::std_ext::*;
-use std::collections::BTreeMap;
-use std::fmt::{self, Debug};
-use std::marker::PhantomData;
-use std::ops::RangeInclusive;
+use alloc::collections::BTreeMap;
+use core::fmt::{self, Debug};
+use core::marker::PhantomData;
+use core::ops::RangeInclusive;
+use core::prelude::v1::*;
 
 /// A map whose keys are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
@@ -65,8 +66,8 @@ where
     /// is a foreign type.
     ///
     /// **NOTE:** This will likely be deprecated and then eventually
-    /// removed once the standard library's [Step](std::iter::Step)
-    /// trait is stabilised, as most crates will then likely implement [Step](std::iter::Step)
+    /// removed once the standard library's [Step](core::iter::Step)
+    /// trait is stabilised, as most crates will then likely implement [Step](core::iter::Step)
     /// for their types where appropriate.
     ///
     /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
@@ -87,7 +88,7 @@ where
     /// Returns the range-value pair (as a pair of references) corresponding
     /// to the given key, if the key is covered by any range in the map.
     pub fn get_key_value(&self, key: &K) -> Option<(&RangeInclusive<K>, &V)> {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // The only stored range that could contain the given key is the
         // last stored range whose start is less than or equal to this key.
@@ -130,7 +131,7 @@ where
     ///
     /// Panics if range `start > end`.
     pub fn insert(&mut self, range: RangeInclusive<K>, value: V) {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // Backwards ranges don't make sense.
         // `RangeInclusive` doesn't enforce this,
@@ -263,7 +264,7 @@ where
     ///
     /// Panics if range `start > end`.
     pub fn remove(&mut self, range: RangeInclusive<K>) {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // Backwards ranges don't make sense.
         // `RangeInclusive` doesn't enforce this,
@@ -339,7 +340,7 @@ where
         new_range: &mut RangeInclusive<K>,
         new_value: &V,
     ) {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
 
         if stored_value == *new_value {
             // The ranges have the same value, so we can "adopt"
@@ -492,15 +493,15 @@ pub struct Gaps<'a, K, V, StepFnsT> {
     /// All other things here are ignored if `done` is `true`.
     done: bool,
     outer_range: &'a RangeInclusive<K>,
-    keys: std::iter::Peekable<
-        std::collections::btree_map::Keys<'a, RangeInclusiveStartWrapper<K>, V>,
+    keys: core::iter::Peekable<
+        alloc::collections::btree_map::Keys<'a, RangeInclusiveStartWrapper<K>, V>,
     >,
     candidate_start: K,
     _phantom: PhantomData<StepFnsT>,
 }
 
 // `Gaps` is always fused. (See definition of `next` below.)
-impl<'a, K, V, StepFnsT> std::iter::FusedIterator for Gaps<'a, K, V, StepFnsT>
+impl<'a, K, V, StepFnsT> core::iter::FusedIterator for Gaps<'a, K, V, StepFnsT>
 where
     K: Ord + Clone,
     StepFnsT: StepFns<K>,
@@ -564,6 +565,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec, vec::Vec};
 
     trait RangeInclusiveMapExt<K, V> {
         fn to_vec(&self) -> Vec<(RangeInclusive<K>, V)>;

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,5 +1,5 @@
-use std::fmt::{self, Debug};
-use std::ops::RangeInclusive;
+use core::fmt::{self, Debug};
+use core::ops::RangeInclusive;
 
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
@@ -47,8 +47,8 @@ where
     /// is a foreign type.
     ///
     /// **NOTE:** This will likely be deprecated and then eventually
-    /// removed once the standard library's [Step](std::iter::Step)
-    /// trait is stabilised, as most crates will then likely implement [Step](std::iter::Step)
+    /// removed once the standard library's [Step](core::iter::Step)
+    /// trait is stabilised, as most crates will then likely implement [Step](core::iter::Step)
     /// for their types where appropriate.
     ///
     /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
@@ -133,7 +133,7 @@ pub struct Gaps<'a, T, StepFnsT> {
 }
 
 // `Gaps` is always fused. (See definition of `next` below.)
-impl<'a, T, StepFnsT> std::iter::FusedIterator for Gaps<'a, T, StepFnsT>
+impl<'a, T, StepFnsT> core::iter::FusedIterator for Gaps<'a, T, StepFnsT>
 where
     T: Ord + Clone,
     StepFnsT: StepFns<T>,
@@ -155,6 +155,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec, vec::Vec};
 
     trait RangeInclusiveSetExt<T> {
         fn to_vec(&self) -> Vec<RangeInclusive<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,13 @@ for (range, person) in roster.iter() {
 [`RangeInclusiveMap`]: crate::RangeInclusiveMap
 [`RangeSet`]: crate::RangeSet
 [`RangeInclusiveSet`]: crate::RangeInclusiveSet
-[`Range`]: std::ops::Range
-[`RangeInclusive`]: std::ops::RangeInclusive
+[`Range`]: core::ops::Range
+[`RangeInclusive`]: core::ops::RangeInclusive
 
 */
+
+#![no_std]
+extern crate alloc;
 
 mod inclusive_map;
 mod inclusive_set;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,8 +1,9 @@
 use super::range_wrapper::RangeStartWrapper;
 use crate::std_ext::*;
-use std::collections::BTreeMap;
-use std::fmt::{self, Debug};
-use std::ops::Range;
+use alloc::collections::BTreeMap;
+use core::fmt::{self, Debug};
+use core::ops::Range;
+use core::prelude::v1::*;
 
 /// A map whose keys are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
@@ -47,7 +48,7 @@ where
     /// Returns the range-value pair (as a pair of references) corresponding
     /// to the given key, if the key is covered by any range in the map.
     pub fn get_key_value(&self, key: &K) -> Option<(&Range<K>, &V)> {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // The only stored range that could contain the given key is the
         // last stored range whose start is less than or equal to this key.
@@ -90,7 +91,7 @@ where
     ///
     /// Panics if range `start >= end`.
     pub fn insert(&mut self, range: Range<K>, value: V) {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // We don't want to have to make empty ranges make sense;
         // they don't represent anything meaningful in this structure.
@@ -200,7 +201,7 @@ where
     ///
     /// Panics if range `start >= end`.
     pub fn remove(&mut self, range: Range<K>) {
-        use std::ops::Bound;
+        use core::ops::Bound;
 
         // We don't want to have to make empty ranges make sense;
         // they don't represent anything meaningful in this structure.
@@ -269,7 +270,7 @@ where
         new_range: &mut Range<K>,
         new_value: &V,
     ) {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
 
         if stored_value == *new_value {
             // The ranges have the same value, so we can "adopt"
@@ -393,12 +394,12 @@ where
 
 pub struct Gaps<'a, K, V> {
     outer_range: &'a Range<K>,
-    keys: std::iter::Peekable<std::collections::btree_map::Keys<'a, RangeStartWrapper<K>, V>>,
+    keys: core::iter::Peekable<alloc::collections::btree_map::Keys<'a, RangeStartWrapper<K>, V>>,
     candidate_start: &'a K,
 }
 
 // `Gaps` is always fused. (See definition of `next` below.)
-impl<'a, K, V> std::iter::FusedIterator for Gaps<'a, K, V> where K: Ord + Clone {}
+impl<'a, K, V> core::iter::FusedIterator for Gaps<'a, K, V> where K: Ord + Clone {}
 
 impl<'a, K, V> Iterator for Gaps<'a, K, V>
 where
@@ -443,6 +444,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec, vec::Vec};
 
     trait RangeMapExt<K, V> {
         fn to_vec(&self) -> Vec<(Range<K>, V)>;

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -10,8 +10,8 @@
 // if you really do want to compare equality of the
 // inner range!
 
-use std::cmp::Ordering;
-use std::ops::{Range, RangeInclusive};
+use core::cmp::Ordering;
+use core::ops::{Range, RangeInclusive};
 
 //
 // Range start wrapper

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,6 @@
-use std::fmt::{self, Debug};
-use std::ops::Range;
+use core::fmt::{self, Debug};
+use core::ops::Range;
+use core::prelude::v1::*;
 
 use crate::RangeMap;
 
@@ -108,7 +109,7 @@ pub struct Gaps<'a, T> {
 }
 
 // `Gaps` is always fused. (See definition of `next` below.)
-impl<'a, T> std::iter::FusedIterator for Gaps<'a, T> where T: Ord + Clone {}
+impl<'a, T> core::iter::FusedIterator for Gaps<'a, T> where T: Ord + Clone {}
 
 impl<'a, T> Iterator for Gaps<'a, T>
 where
@@ -124,6 +125,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, vec, vec::Vec};
 
     trait RangeSetExt<T> {
         fn to_vec(&self) -> Vec<Range<T>>;

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Range, RangeInclusive, Sub};
+use core::ops::{Add, Range, RangeInclusive, Sub};
 
 pub trait RangeExt<T> {
     fn overlaps(&self, other: &Self) -> bool;
@@ -10,13 +10,13 @@ where
     T: Ord,
 {
     fn overlaps(&self, other: &Self) -> bool {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
         // Strictly less than, because ends are excluded.
         max(&self.start, &other.start) < min(&self.end, &other.end)
     }
 
     fn touches(&self, other: &Self) -> bool {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
         // Less-than-or-equal-to because if one end is excluded, the other is included.
         // I.e. the two could be joined into a single range, because they're overlapping
         // or immediately adjacent.
@@ -36,7 +36,7 @@ where
     T: Ord + Clone,
 {
     fn overlaps(&self, other: &Self) -> bool {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
         // Less than or equal, because ends are included.
         max(self.start(), other.start()) <= min(self.end(), other.end())
     }
@@ -45,7 +45,7 @@ where
     where
         StepFnsT: StepFns<T>,
     {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
 
         // Touching for end-inclusive ranges is equivalent to touching of
         // slightly longer end-inclusive ranges.
@@ -67,7 +67,7 @@ where
     }
 }
 
-/// Minimal version of unstable [`Step`](std::iter::Step) trait
+/// Minimal version of unstable [`Step`](core::iter::Step) trait
 /// from the Rust standard library.
 ///
 /// This is needed for [`RangeInclusiveMap`](crate::RangeInclusiveMap)
@@ -111,7 +111,7 @@ macro_rules! impl_step_lite {
 impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
 // TODO: When on nightly, a blanket implementation for
-// all types that implement `std::iter::Step` instead
+// all types that implement `core::iter::Step` instead
 // of the auto-impl above.
 
 /// Successor and predecessor functions defined for `T`,
@@ -122,7 +122,7 @@ impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 /// is a foreign type.
 ///
 /// **NOTE:** This will likely be deprecated and then eventually
-/// removed once the standard library's [`Step`](std::iter::Step)
+/// removed once the standard library's [`Step`](core::iter::Step)
 /// trait is stabilised, as most crates will then likely implement `Step`
 /// for their types where appropriate.
 ///

--- a/src/stupid_range_map.rs
+++ b/src/stupid_range_map.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
-use std::ops::RangeInclusive;
+use alloc::collections::BTreeMap;
+use core::ops::RangeInclusive;
 
 use super::{RangeInclusiveMap, RangeMap};
 


### PR DESCRIPTION
Hey there,
I have to say, this crate is very nice! In one of our projects we need support no_std, and rangemap not being marked as no_std blocks it from being used. This PR adds support for compiling only with libcore and liballoc. It could have been done by renaming all paths to core/alloc, but it ends up being rather verbose and alien, thus I added a no-std-compat crate as a dependency. It's a very thin crate with no additional dependencies. However, I could also redo the change without using external dependencies, if you would like that instead. If there are any other changes needed, I'd be glad to add them!