### PR TITLE
Add `IntoIterator` implementations

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -473,6 +473,28 @@ where
     }
 }
 
+pub struct IntoIter<K, V> {
+    inner: alloc::collections::btree_map::IntoIter<RangeInclusiveStartWrapper<K>, V>,
+}
+impl<K, V> IntoIterator for RangeInclusiveMap<K, V> {
+    type Item = (RangeInclusive<K>, V);
+    type IntoIter = IntoIter<K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.btm.into_iter(),
+        }
+    }
+}
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (RangeInclusive<K>, V);
+    fn next(&mut self) -> Option<(RangeInclusive<K>, V)> {
+        self.inner.next().map(|(by_start, v)| (by_start.range, v))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
 // We can't just derive this automatically, because that would
 // expose irrelevant (and private) implementation details.
 // Instead implement it in the same way that the underlying BTreeMap does.

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -116,6 +116,28 @@ where
     }
 }
 
+pub struct IntoIter<T> {
+    inner: super::inclusive_map::IntoIter<T, ()>,
+}
+impl<T> IntoIterator for RangeInclusiveSet<T> {
+    type Item = RangeInclusive<T>;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.rm.into_iter(),
+        }
+    }
+}
+impl<T> Iterator for IntoIter<T> {
+    type Item = RangeInclusive<T>;
+    fn next(&mut self) -> Option<RangeInclusive<T>> {
+        self.inner.next().map(|(range, _)| range)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
 // We can't just derive this automatically, because that would
 // expose irrelevant (and private) implementation details.
 // Instead implement it in the same way that the underlying BTreeSet does.

--- a/src/set.rs
+++ b/src/set.rs
@@ -92,6 +92,28 @@ where
     }
 }
 
+pub struct IntoIter<T> {
+    inner: super::map::IntoIter<T, ()>,
+}
+impl<T> IntoIterator for RangeSet<T> {
+    type Item = Range<T>;
+    type IntoIter = IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.rm.into_iter(),
+        }
+    }
+}
+impl<T> Iterator for IntoIter<T> {
+    type Item = Range<T>;
+    fn next(&mut self) -> Option<Range<T>> {
+        self.inner.next().map(|(range, _)| range)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
 // We can't just derive this automatically, because that would
 // expose irrelevant (and private) implementation details.
 // Instead implement it in the same way that the underlying BTreeSet does.


### PR DESCRIPTION
Hi! I'd love to use RangeMap in a project, but I'd like to be able to consume it (to avoid cloning everything).

I added some simple `IntoIter` structs and `IntoIterator` implementations (using the equivalent `std::collections::..` types and the existing `iter()` methods as a template).

I only added a test for `RangeMap` itself, since the implementations are pretty straightforward and identical, but I can add more if you'd like. I also ran `pre-commit.sh` to test everything.

This is related to #3, as it increases feature parity with the `std` types.