### PR TITLE
Add range iterator and contains_any/all to all container types

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -116,6 +116,18 @@ where
         self.get(key).is_some()
     }
 
+    /// Returns `true` if any part of the provided range overlaps with a range in the map.
+    #[inline]
+    pub fn contains_any<'a>(&self, range: &'a RangeInclusive<K>) -> bool {
+        self.range(range).next().is_some()
+    }
+
+    /// Returns `true` if all of the provided range is covered by ranges in the map.
+    #[inline]
+    pub fn contains_all<'a>(&self, range: &'a RangeInclusive<K>) -> bool {
+        self.gaps(range).next().is_none()
+    }
+
     /// Gets an iterator over all pairs of key range and value,
     /// ordered by key range.
     ///
@@ -427,6 +439,28 @@ where
         }
     }
 
+    /// Gets an iterator over all pairs of key range and value, where the key range overlaps with
+    /// the provided range.
+    ///
+    /// The iterator element type is `(&'a RangeInclusive<K>, &'a V)`.
+    pub fn range<'a>(&'a self, range: &'a RangeInclusive<K>) -> RangeIter<'a, K, V> {
+        use core::ops::Bound;
+
+        let start = self
+            .get_key_value(range.start())
+            .map_or(range.start(), |(k, _v)| k.start());
+        let end = range.end();
+
+        RangeIter {
+            inner: self.btm.range((
+                Bound::Included(RangeInclusiveStartWrapper::new(
+                    start.clone()..=start.clone(),
+                )),
+                Bound::Included(RangeInclusiveStartWrapper::new(end.clone()..=end.clone())),
+            )),
+        }
+    }
+
     /// Gets an iterator over all the maximally-sized ranges
     /// contained in `outer_range` that are not covered by
     /// any range stored in the map.
@@ -649,6 +683,36 @@ where
             range_inclusive_map.insert(start..=end, value);
         }
         Ok(range_inclusive_map)
+    }
+}
+
+/// An iterator over entries of a `RangeInclusiveMap` whose range overlaps with a specified range.
+///
+/// The iterator element type is `(&'a RangeInclusive<K>, &'a V)`.
+///
+/// This `struct` is created by the [`range`] method on [`RangeInclusiveMap`]. See its
+/// documentation for more.
+///
+/// [`range`]: RangeInclusiveMap::range
+pub struct RangeIter<'a, K, V> {
+    inner: alloc::collections::btree_map::Range<'a, RangeInclusiveStartWrapper<K>, V>,
+}
+
+impl<'a, K, V> core::iter::FusedIterator for RangeIter<'a, K, V> where K: Ord + Clone {}
+
+impl<'a, K, V> Iterator for RangeIter<'a, K, V>
+where
+    K: 'a,
+    V: 'a,
+{
+    type Item = (&'a RangeInclusive<K>, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(by_start, v)| (&by_start.range, v))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -78,6 +78,18 @@ where
         self.rm.contains_key(value)
     }
 
+    /// Returns `true` if any part of the provided range overlaps with a range in the map.
+    #[inline]
+    pub fn contains_any<'a>(&self, range: &'a RangeInclusive<T>) -> bool {
+        self.range(range).next().is_some()
+    }
+
+    /// Returns `true` if all of the provided range is covered by ranges in the map.
+    #[inline]
+    pub fn contains_all<'a>(&self, range: &'a RangeInclusive<T>) -> bool {
+        self.gaps(range).next().is_none()
+    }
+
     /// Gets an ordered iterator over all ranges,
     /// ordered by range.
     pub fn iter(&self) -> Iter<'_, T> {
@@ -110,6 +122,13 @@ where
     /// Panics if range `start > end`.
     pub fn remove(&mut self, range: RangeInclusive<T>) {
         self.rm.remove(range);
+    }
+
+    /// Gets an iterator over all ranges that overlap with the provided range.
+    pub fn range<'a>(&'a self, range: &'a RangeInclusive<T>) -> RangeIter<'a, T> {
+        RangeIter {
+            inner: self.rm.range(range),
+        }
     }
 
     /// Gets an iterator over all the maximally-sized ranges
@@ -278,6 +297,33 @@ where
             range_inclusive_set.insert(start..=end);
         }
         Ok(range_inclusive_set)
+    }
+}
+
+/// An iterator over ranges of a `RangeInclusiveSet` that overlap with a specified range.
+///
+/// This `struct` is created by the [`range`] method on [`RangeInclusiveSet`]. See its
+/// documentation for more.
+///
+/// [`range`]: RangeInclusiveSet::range
+pub struct RangeIter<'a, T> {
+    inner: crate::inclusive_map::RangeIter<'a, T, ()>,
+}
+
+impl<'a, T> core::iter::FusedIterator for RangeIter<'a, T> where T: Ord + Clone {}
+
+impl<'a, T> Iterator for RangeIter<'a, T>
+where
+    T: 'a,
+{
+    type Item = &'a RangeInclusive<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(range, _)| range)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -54,6 +54,18 @@ where
         self.rm.contains_key(value)
     }
 
+    /// Returns `true` if any part of the provided range overlaps with a range in the map.
+    #[inline]
+    pub fn contains_any<'a>(&self, range: &'a Range<T>) -> bool {
+        self.range(range).next().is_some()
+    }
+
+    /// Returns `true` if all of the provided range is covered by ranges in the map.
+    #[inline]
+    pub fn contains_all<'a>(&self, range: &'a Range<T>) -> bool {
+        self.gaps(range).next().is_none()
+    }
+
     /// Gets an ordered iterator over all ranges,
     /// ordered by range.
     pub fn iter(&self) -> Iter<'_, T> {
@@ -86,6 +98,13 @@ where
     /// Panics if range `start >= end`.
     pub fn remove(&mut self, range: Range<T>) {
         self.rm.remove(range);
+    }
+
+    /// Gets an iterator over all ranges that overlap with the provided range.
+    pub fn range<'a>(&'a self, range: &'a Range<T>) -> RangeIter<'a, T> {
+        RangeIter {
+            inner: self.rm.range(range),
+        }
     }
 
     /// Gets an iterator over all the maximally-sized ranges
@@ -254,6 +273,33 @@ where
             range_set.insert(start..end);
         }
         Ok(range_set)
+    }
+}
+
+/// An iterator over ranges of a `RangeSet` that overlap with a specified range.
+///
+/// This `struct` is created by the [`range`] method on [`RangeSet`]. See its
+/// documentation for more.
+///
+/// [`range`]: RangeSet::range
+pub struct RangeIter<'a, T> {
+    inner: crate::map::RangeIter<'a, T, ()>,
+}
+
+impl<'a, T> core::iter::FusedIterator for RangeIter<'a, T> where T: Ord + Clone {}
+
+impl<'a, T> Iterator for RangeIter<'a, T>
+where
+    T: 'a,
+{
+    type Item = &'a Range<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(range, _)| range)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
     }
 }
 


### PR DESCRIPTION
Fixes #23. The implementation mostly reuses existing patterns and code in the crate already.