### PR TITLE
Fix empty ranges returned by `Gaps` iterators

### DIFF
--- a/README.fuzz.md
+++ b/README.fuzz.md
@@ -7,4 +7,6 @@ Run one of these:
 ```
 cargo +nightly fuzz run rangemap_coalesce
 cargo +nightly fuzz run rangemap_inclusive_coalesce
+cargo +nightly fuzz run rangemap_gaps
+cargo +nightly fuzz run rangemap_inclusive_gaps
 ```

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,15 @@ name = "rangemap_inclusive_coalesce"
 path = "fuzz_targets/rangemap_inclusive_coalesce.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "rangemap_gaps"
+path = "fuzz_targets/rangemap_gaps.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "rangemap_inclusive_gaps"
+path = "fuzz_targets/rangemap_inclusive_gaps.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/rangemap_gaps.rs
+++ b/fuzz/fuzz_targets/rangemap_gaps.rs
@@ -1,0 +1,81 @@
+#![feature(array_windows)]
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use arbitrary::{Arbitrary, Unstructured};
+use rangemap::RangeMap;
+use std::ops::Range;
+
+#[derive(Clone, Debug, Arbitrary)]
+enum Op {
+    Insert(Range<u8>, u8),
+    Remove(Range<u8>),
+}
+
+impl Op {
+    fn apply(self, map: &mut RangeMap<u8, u8>) {
+        match self {
+            Op::Insert(r, v) if r.start < r.end => map.insert(r, v),
+            Op::Remove(r) if r.start < r.end => map.remove(r),
+            _ => (),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Input {
+    ops: Vec<Op>,
+    outer_range: Range<u8>,
+}
+
+impl Arbitrary for Input {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        Ok(Self {
+            ops: u.arbitrary()?,
+            // Larger margins than that are too
+            // far away from boundary conditions to be interesting.
+            // ("Oh, the fools! If only they'd built it with 6,001 hulls." -- Philip J. Fry)
+            //
+            // NOTE: Not using `int_in_range` because of <https://github.com/rust-fuzz/arbitrary/issues/106>.
+            outer_range: *u.choose(&[0, 1, 2, 3])?..*u.choose(&[252, 253, 254, 255])?,
+        })
+    }
+}
+
+fuzz_target!(|input: Input| {
+    let Input { ops, outer_range } = input;
+
+    let mut map = RangeMap::new();
+
+    for op in ops {
+        op.apply(&mut map);
+    }
+
+    // Check that the combination of gaps and keys fills the entire outer range.
+    let gaps: Vec<Range<u8>> = map.gaps(&outer_range).collect();
+    // TODO: Replace the filtering and mapping with a `range` iterator
+    // on the map itself.
+    let mut keys: Vec<Range<u8>> = map
+        .into_iter()
+        .map(|(k, _v)| k)
+        .filter(|Range { start, end }| {
+            // Reject anything with zero of its width inside the outer range.
+            *end > outer_range.start && *start < outer_range.end
+        })
+        .map(|Range { start, end }| {
+            // Truncate anything straddling either edge.
+            u8::max(start, outer_range.start)..u8::min(end, outer_range.end)
+        })
+        .collect();
+    keys.extend(gaps.into_iter());
+    keys.sort_by_key(|key| key.start);
+
+    // Gaps and keys combined should span whole outer range.
+    assert_eq!(keys.first().unwrap().start, outer_range.start);
+    assert_eq!(keys.last().unwrap().end, outer_range.end);
+
+    // Each gap/key should start where the previous one ended.
+    for [a, b] in keys.array_windows::<2>() {
+        assert_eq!(a.end, b.start);
+    }
+});

--- a/fuzz/fuzz_targets/rangemap_inclusive_gaps.rs
+++ b/fuzz/fuzz_targets/rangemap_inclusive_gaps.rs
@@ -1,0 +1,81 @@
+#![feature(array_windows)]
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use arbitrary::{Arbitrary, Unstructured};
+use rangemap::RangeInclusiveMap;
+use std::ops::RangeInclusive;
+
+#[derive(Clone, Debug, Arbitrary)]
+enum Op {
+    Insert(RangeInclusive<u8>, u8),
+    Remove(RangeInclusive<u8>),
+}
+
+impl Op {
+    fn apply(self, map: &mut RangeInclusiveMap<u8, u8>) {
+        match self {
+            Op::Insert(r, v) => map.insert(r, v),
+            Op::Remove(r) => map.remove(r),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Input {
+    ops: Vec<Op>,
+    outer_range: RangeInclusive<u8>,
+}
+
+impl Arbitrary for Input {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        Ok(Self {
+            ops: u.arbitrary()?,
+            // Larger margins than that are too
+            // far away from boundary conditions to be interesting.
+            // ("Oh, the fools! If only they'd built it with 6,001 hulls." -- Philip J. Fry)
+            //
+            // NOTE: Not using `int_in_range` because of <https://github.com/rust-fuzz/arbitrary/issues/106>.
+            outer_range: *u.choose(&[0, 1, 2, 3])?..=*u.choose(&[252, 253, 254, 255])?,
+        })
+    }
+}
+
+fuzz_target!(|input: Input| {
+    let Input { ops, outer_range } = input;
+
+    let mut map = RangeInclusiveMap::new();
+
+    for op in ops {
+        op.apply(&mut map);
+    }
+
+    // Check that the combination of gaps and keys fills the entire outer range.
+    let gaps: Vec<RangeInclusive<u8>> = map.gaps(&outer_range).collect();
+    // TODO: Replace the filtering and mapping with a `range` iterator
+    // on the map itself.
+    let mut keys: Vec<RangeInclusive<u8>> = map
+        .into_iter()
+        .map(|(k, _v)| k)
+        .filter(|range| {
+            // Reject anything with zero of its width inside the outer range.
+            *range.end() >= *outer_range.start() && *range.start() <= *outer_range.end()
+        })
+        .map(|range| {
+            // Truncate anything straddling either edge.
+            u8::max(*range.start(), *outer_range.start())
+                ..=u8::min(*range.end(), *outer_range.end())
+        })
+        .collect();
+    keys.extend(gaps.into_iter());
+    keys.sort_by_key(|key| *key.start());
+
+    // Gaps and keys combined should span whole outer range.
+    assert_eq!(keys.first().unwrap().start(), outer_range.start());
+    assert_eq!(keys.last().unwrap().end(), outer_range.end());
+
+    // Each gap/key should start where the previous one ended.
+    for [a, b] in keys.array_windows::<2>() {
+        assert_eq!(*a.end() + 1, *b.start());
+    }
+});

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -14,18 +14,18 @@ use super::{RangeInclusiveMap, RangeMap};
 // of `RangeInclusiveMap`, it can also be used to
 // test `RangeMap` just fine.
 #[derive(Eq, PartialEq, Debug)]
-pub struct StupidU32RangeMap<V> {
+pub struct DenseU32RangeMap<V> {
     // Inner B-Tree map. Stores values and their keys
     // directly rather than as ranges.
     btm: BTreeMap<u32, V>,
 }
 
-impl<V> StupidU32RangeMap<V>
+impl<V> DenseU32RangeMap<V>
 where
     V: Eq + Clone,
 {
-    pub fn new() -> StupidU32RangeMap<V> {
-        StupidU32RangeMap {
+    pub fn new() -> DenseU32RangeMap<V> {
+        DenseU32RangeMap {
             btm: BTreeMap::new(),
         }
     }
@@ -37,12 +37,12 @@ where
     }
 }
 
-impl<V> From<RangeMap<u32, V>> for StupidU32RangeMap<V>
+impl<V> From<RangeMap<u32, V>> for DenseU32RangeMap<V>
 where
     V: Eq + Clone,
 {
     fn from(range_map: RangeMap<u32, V>) -> Self {
-        let mut stupid = Self::new();
+        let mut dense = Self::new();
         for (range, value) in range_map.iter() {
             // Convert to inclusive end.
             // (This is only valid because u32 has
@@ -51,21 +51,21 @@ where
             // NOTE: Clippy's `range_minus_one` lint is a bit overzealous here,
             // because we _can't_ pass an open-ended range to `insert`.
             #[allow(clippy::range_minus_one)]
-            stupid.insert(range.start..=(range.end - 1), value.clone());
+            dense.insert(range.start..=(range.end - 1), value.clone());
         }
-        stupid
+        dense
     }
 }
 
-impl<V> From<RangeInclusiveMap<u32, V>> for StupidU32RangeMap<V>
+impl<V> From<RangeInclusiveMap<u32, V>> for DenseU32RangeMap<V>
 where
     V: Eq + Clone,
 {
     fn from(range_inclusive_map: RangeInclusiveMap<u32, V, u32>) -> Self {
-        let mut stupid = Self::new();
+        let mut dense = Self::new();
         for (range, value) in range_inclusive_map.iter() {
-            stupid.insert(range.clone(), value.clone());
+            dense.insert(range.clone(), value.clone());
         }
-        stupid
+        dense
     }
 }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1,5 +1,5 @@
-use alloc::collections::BTreeMap;
-use core::ops::RangeInclusive;
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::ops::{Range, RangeInclusive};
 
 use super::{RangeInclusiveMap, RangeMap};
 
@@ -35,6 +35,31 @@ where
             self.btm.insert(k, value.clone());
         }
     }
+
+    pub fn iter(&self) -> Iter<'_, V> {
+        Iter {
+            inner: self.btm.iter(),
+            current: None,
+        }
+    }
+
+    pub fn end_exclusive_iter(&self) -> EndExclusiveIter<'_, V> {
+        EndExclusiveIter { inner: self.iter() }
+    }
+
+    // Vecs are easier to use for assertions than iterators,
+    // because you don't have to consume them to compare them.
+    pub fn to_vec(&self) -> Vec<(RangeInclusive<u32>, V)> {
+        self.iter()
+            .map(|(range, value)| (range, value.clone()))
+            .collect()
+    }
+
+    pub fn to_end_exclusive_vec(&self) -> Vec<(Range<u32>, V)> {
+        self.end_exclusive_iter()
+            .map(|(range, value)| (range, value.clone()))
+            .collect()
+    }
 }
 
 impl<V> From<RangeMap<u32, V>> for DenseU32RangeMap<V>
@@ -67,5 +92,67 @@ where
             dense.insert(range.clone(), value.clone());
         }
         dense
+    }
+}
+
+pub struct Iter<'a, V> {
+    inner: alloc::collections::btree_map::Iter<'a, u32, V>,
+    // Current range being built for output.
+    // We modify it as we iterate through the underlying
+    // dense map.
+    current: Option<(RangeInclusive<u32>, &'a V)>,
+}
+
+// Coalesce items from the underlying dense map as we go.
+impl<'a, V> Iterator for Iter<'a, V>
+where
+    V: 'a + Eq,
+{
+    type Item = (RangeInclusive<u32>, &'a V);
+
+    fn next(&mut self) -> Option<(RangeInclusive<u32>, &'a V)> {
+        if let Some(next_dense) = self.inner.next() {
+            if let Some(current) = &mut self.current {
+                // We're already building a range. Can we extend it?
+                if current.0.end() + 1 == *next_dense.0 && *current.1 == *next_dense.1 {
+                    // This immediately follows the last item and the value is the same;
+                    // we can extend it.
+                    *current = (*current.0.start()..=*next_dense.0, current.1);
+                    // Recurse until we find a way to flush it.
+                    self.next()
+                } else {
+                    // There's a gap or the value differs; flush the one we were working on and start a new one.
+                    let item_to_yield = current.clone();
+                    *current = (*next_dense.0..=*next_dense.0, next_dense.1);
+                    Some(item_to_yield)
+                }
+            } else {
+                // We're not building a range yet; start a new one.
+                self.current = Some((*next_dense.0..=*next_dense.0, next_dense.1));
+                // Recurse until we find a way to flush it.
+                self.next()
+            }
+        } else {
+            // We reached the end of the underlying dense map.
+            // Flush the item we were building, if any.
+            self.current.take()
+        }
+    }
+}
+
+pub struct EndExclusiveIter<'a, V> {
+    inner: Iter<'a, V>,
+}
+
+impl<'a, V> Iterator for EndExclusiveIter<'a, V>
+where
+    V: 'a + Eq,
+{
+    type Item = (Range<u32>, &'a V);
+
+    fn next(&mut self) -> Option<(Range<u32>, &'a V)> {
+        self.inner
+            .next()
+            .map(|(range, value)| ((*range.start())..(*range.end() + 1), value))
     }
 }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -954,16 +954,17 @@ mod tests {
 
         ranges_with_values.permutation().for_each(|permutation| {
             let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
-            let mut stupid: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
+            let mut dense: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
 
             for (k, v) in permutation {
                 // Insert it into both maps.
                 range_map.insert(k.clone(), v);
-                stupid.insert(k, v);
+                dense.insert(k, v);
 
                 // At every step, both maps should contain the same stuff.
-                let stupid2: DenseU32RangeMap<bool> = range_map.clone().into();
-                assert_eq!(stupid, stupid2);
+                let sparse = range_map.to_vec();
+                let dense = dense.to_vec();
+                assert_eq!(sparse, dense);
             }
         });
     }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -934,7 +934,7 @@ mod tests {
     #[test]
     // Test every permutation of a bunch of touching and overlapping ranges.
     fn lots_of_interesting_ranges() {
-        use crate::stupid_range_map::StupidU32RangeMap;
+        use crate::dense::DenseU32RangeMap;
         use permutator::Permutation;
 
         let mut ranges_with_values = [
@@ -954,7 +954,7 @@ mod tests {
 
         ranges_with_values.permutation().for_each(|permutation| {
             let mut range_map: RangeInclusiveMap<u32, bool> = RangeInclusiveMap::new();
-            let mut stupid: StupidU32RangeMap<bool> = StupidU32RangeMap::new();
+            let mut stupid: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
 
             for (k, v) in permutation {
                 // Insert it into both maps.
@@ -962,7 +962,7 @@ mod tests {
                 stupid.insert(k, v);
 
                 // At every step, both maps should contain the same stuff.
-                let stupid2: StupidU32RangeMap<bool> = range_map.clone().into();
+                let stupid2: DenseU32RangeMap<bool> = range_map.clone().into();
                 assert_eq!(stupid, stupid2);
             }
         });

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -117,9 +117,6 @@ where
     /// any range stored in the set.
     ///
     /// The iterator element type is `RangeInclusive<T>`.
-    ///
-    /// NOTE: Calling `gaps` eagerly finds the first gap,
-    /// even if the iterator is never consumed.
     pub fn gaps<'a>(&'a self, outer_range: &'a RangeInclusive<T>) -> Gaps<'a, T, StepFnsT> {
         Gaps {
             inner: self.rm.gaps(outer_range),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,10 @@ pub mod inclusive_set;
 pub mod map;
 pub mod set;
 
+#[cfg(test)]
+mod dense;
 mod range_wrapper;
 mod std_ext;
-#[cfg(test)]
-mod stupid_range_map;
 
 pub use inclusive_map::RangeInclusiveMap;
 pub use inclusive_set::RangeInclusiveSet;

--- a/src/map.rs
+++ b/src/map.rs
@@ -826,7 +826,7 @@ mod tests {
 
         ranges_with_values.permutation().for_each(|permutation| {
             let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-            let mut stupid: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
+            let mut dense: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
 
             for (k, v) in permutation {
                 // Insert it into both maps.
@@ -834,11 +834,12 @@ mod tests {
                 // NOTE: Clippy's `range_minus_one` lint is a bit overzealous here,
                 // because we _can't_ pass an open-ended range to `insert`.
                 #[allow(clippy::range_minus_one)]
-                stupid.insert(k.start..=(k.end - 1), v);
+                dense.insert(k.start..=(k.end - 1), v);
 
                 // At every step, both maps should contain the same stuff.
-                let stupid2: DenseU32RangeMap<bool> = range_map.clone().into();
-                assert_eq!(stupid, stupid2);
+                let sparse = range_map.to_vec();
+                let dense = dense.to_end_exclusive_vec();
+                assert_eq!(sparse, dense);
             }
         });
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -806,7 +806,7 @@ mod tests {
     #[test]
     // Test every permutation of a bunch of touching and overlapping ranges.
     fn lots_of_interesting_ranges() {
-        use crate::stupid_range_map::StupidU32RangeMap;
+        use crate::dense::DenseU32RangeMap;
         use permutator::Permutation;
 
         let mut ranges_with_values = [
@@ -826,7 +826,7 @@ mod tests {
 
         ranges_with_values.permutation().for_each(|permutation| {
             let mut range_map: RangeMap<u32, bool> = RangeMap::new();
-            let mut stupid: StupidU32RangeMap<bool> = StupidU32RangeMap::new();
+            let mut stupid: DenseU32RangeMap<bool> = DenseU32RangeMap::new();
 
             for (k, v) in permutation {
                 // Insert it into both maps.
@@ -837,7 +837,7 @@ mod tests {
                 stupid.insert(k.start..=(k.end - 1), v);
 
                 // At every step, both maps should contain the same stuff.
-                let stupid2: StupidU32RangeMap<bool> = range_map.clone().into();
+                let stupid2: DenseU32RangeMap<bool> = range_map.clone().into();
                 assert_eq!(stupid, stupid2);
             }
         });

--- a/src/set.rs
+++ b/src/set.rs
@@ -92,10 +92,11 @@ where
     /// contained in `outer_range` that are not covered by
     /// any range stored in the set.
     ///
-    /// The iterator element type is `Range<T>`.
+    /// If the start and end of the outer range are the same
+    /// and it does not overlap any stored range, then a single
+    /// empty gap will be returned.
     ///
-    /// NOTE: Calling `gaps` eagerly finds the first gap,
-    /// even if the iterator is never consumed.
+    /// The iterator element type is `Range<T>`.
     pub fn gaps<'a>(&'a self, outer_range: &'a Range<T>) -> Gaps<'a, T> {
         Gaps {
             inner: self.rm.gaps(outer_range),


### PR DESCRIPTION
They were sometimes returning empty ranges still, and the implementation
was unnecessarily complex. There may well have been other bugs hiding in
there.

Fixes https://github.com/jeffparsons/rangemap/issues/43.

This also adds fuzzing of the gaps iterators to get a bit more confidence
that they're actually right now, including fuzzing the size of the outer
range.