### PR TITLE
Don't yield an empty gap for an empty outer range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### (unreleased)
+
+- **Fixes**:
+    - Fix `Gaps` iterator for `RangeMap` yielding an empty gap for an empty outer range. Simplified gaps logic and expanded fuzz testing to better cover this and similar cases.
+
+
 ### v1.0.2 (2022-05-17)
 
 - **Fixes**:

--- a/fuzz/fuzz_targets/rangemap_gaps.rs
+++ b/fuzz/fuzz_targets/rangemap_gaps.rs
@@ -32,12 +32,13 @@ impl Arbitrary for Input {
     fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
         Ok(Self {
             ops: u.arbitrary()?,
-            // Larger margins than that are too
+            // Larger margins than these are too
             // far away from boundary conditions to be interesting.
             // ("Oh, the fools! If only they'd built it with 6,001 hulls." -- Philip J. Fry)
             //
             // NOTE: Not using `int_in_range` because of <https://github.com/rust-fuzz/arbitrary/issues/106>.
-            outer_range: *u.choose(&[0, 1, 2, 3])?..*u.choose(&[252, 253, 254, 255])?,
+            outer_range: *u.choose(&[0, 1, 2, 3, 100, 101, 102, 103])?
+                ..*u.choose(&[100, 101, 102, 103, 252, 253, 254, 255])?,
         })
     }
 }
@@ -66,9 +67,21 @@ fuzz_target!(|input: Input| {
             // Truncate anything straddling either edge.
             u8::max(start, outer_range.start)..u8::min(end, outer_range.end)
         })
+        .filter(|range| {
+            // Reject anything that is now empty after being truncated.
+            !range.is_empty()
+        })
         .collect();
+
     keys.extend(gaps.into_iter());
     keys.sort_by_key(|key| key.start);
+
+    if outer_range.is_empty() {
+        // There should be no gaps or keys returned if the outer range is empty,
+        // because empty ranges cover no values.
+        assert!(keys.is_empty());
+        return;
+    }
 
     // Gaps and keys combined should span whole outer range.
     assert_eq!(keys.first().unwrap().start, outer_range.start);


### PR DESCRIPTION
An empty gap is meaningless, and an empty outer range
has no values that could be considered a gap.

I've also yet again slightly simplified the gaps logic to make
it clearer what's going on.

Fixes https://github.com/jeffparsons/rangemap/issues/47