### PR TITLE
Make `RangeMap::new()` and `RangeSet::new()` const functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ serde_json = "1"
 serde1 = ["serde"]
 # So we can run doc tests from "README.md".
 nightly = []
+# Enables `RangeMap::new()` and `RangeSet::new()` to be const functions.
+# Requires a nightly compiler because `const_btree_new` is an unstable feature,
+# but is soon to be stabilized: <https://github.com/rust-lang/rust/issues/71835>
+const_fn = []
 
 [[bench]]
 name = "kitchen_sink"

--- a/pre_commit.sh
+++ b/pre_commit.sh
@@ -7,6 +7,8 @@ cargo test
 cargo +nightly test --features nightly
 # And just with serde1.
 cargo test --features serde1
+# And with const functions.
+cargo +nightly test --features const_fn
 cargo run --example roster
 cargo fmt
 cargo clippy --bins --examples --tests --benches -- -D warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ book for general information about operating without the standard library.
 */
 
 #![no_std]
+#![cfg_attr(feature = "const_fn", feature(const_btree_new))]
 extern crate alloc;
 
 pub mod inclusive_map;

--- a/src/map.rs
+++ b/src/map.rs
@@ -42,6 +42,15 @@ where
     V: Eq + Clone,
 {
     /// Makes a new empty `RangeMap`.
+    #[cfg(feature = "const_fn")]
+    pub const fn new() -> Self {
+        RangeMap {
+            btm: BTreeMap::new(),
+        }
+    }
+
+    /// Makes a new empty `RangeMap`.
+    #[cfg(not(feature = "const_fn"))]
     pub fn new() -> Self {
         RangeMap {
             btm: BTreeMap::new(),

--- a/src/set.rs
+++ b/src/set.rs
@@ -38,6 +38,15 @@ where
     T: Ord + Clone,
 {
     /// Makes a new empty `RangeSet`.
+    #[cfg(feature = "const_fn")]
+    pub const fn new() -> Self {
+        RangeSet {
+            rm: RangeMap::new(),
+        }
+    }
+
+    /// Makes a new empty `RangeSet`.
+    #[cfg(not(feature = "const_fn"))]
     pub fn new() -> Self {
         RangeSet {
             rm: RangeMap::new(),


### PR DESCRIPTION
Thanks for this awesome crate!

This PR makes it possible to construct a `RangeMap` and `RangeSet` in a const context without paying the overhead of `lazy_static` or similar lazy init wrappers. For example, this now works:
```rust
static MY_RANGEMAP: RangeMap<usize, String> = RangeMap::new();
```

I've gated it behind the `const_fn` feature in the Cargo.toml, because it requires a nightly compiler to enable the `const_btree_new` Rust feature. You can build it like so:
```sh
cargo +nightly build --features const_fn
```

Tested and working in Theseus OS :+1: 

I'm happy to make any requested changes.

