### PR TITLE
Add PartialEq and Eq derives

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -49,41 +49,45 @@ where
     }
 }
 
-impl<K, V> PartialEq for RangeInclusiveMap<K, V, K>
+impl<K, V, StepFnsT> PartialEq for RangeInclusiveMap<K, V, StepFnsT>
 where
-    K: Eq,
+    K: Ord,
     V: Eq,
+    StepFnsT: StepFns<K>,
 {
-    fn eq(&self, other: &RangeInclusiveMap<K, V, K>) -> bool {
+    fn eq(&self, other: &RangeInclusiveMap<K, V, StepFnsT>) -> bool {
         self.btm == other.btm
     }
 }
 
-impl<K, V> Eq for RangeInclusiveMap<K, V, K>
+impl<K, V, StepFnsT> Eq for RangeInclusiveMap<K, V, StepFnsT>
 where
-    K: Eq,
+    K: Ord,
     V: Eq,
+    StepFnsT: StepFns<K>,
 {
 }
 
-impl<K, V> PartialOrd for RangeInclusiveMap<K, V, K>
+impl<K, V, StepFnsT> PartialOrd for RangeInclusiveMap<K, V, StepFnsT>
 where
     K: Ord + PartialOrd,
     V: Ord + PartialOrd,
+    StepFnsT: StepFns<K>,
 {
     #[inline]
-    fn partial_cmp(&self, other: &RangeInclusiveMap<K, V, K>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &RangeInclusiveMap<K, V, StepFnsT>) -> Option<Ordering> {
         self.btm.partial_cmp(&other.btm)
     }
 }
 
-impl<K, V> Ord for RangeInclusiveMap<K, V, K>
+impl<K, V, StepFnsT> Ord for RangeInclusiveMap<K, V, StepFnsT>
 where
     K: Ord,
     V: Ord,
+    StepFnsT: StepFns<K>,
 {
     #[inline]
-    fn cmp(&self, other: &RangeInclusiveMap<K, V, K>) -> Ordering {
+    fn cmp(&self, other: &RangeInclusiveMap<K, V, StepFnsT>) -> Ordering {
         self.btm.cmp(&other.btm)
     }
 }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -30,8 +30,11 @@ use serde::{
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone)]
-pub struct RangeInclusiveMap<K, V, StepFnsT = K> {
+#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
+pub struct RangeInclusiveMap<K, V, StepFnsT = K>
+where
+    K: Ord + Clone,
+{
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeInclusiveStartWrapper<K>, V>,
@@ -486,7 +489,10 @@ pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeInclusiveStartWrapper<K>, V>,
 }
 
-impl<K, V> IntoIterator for RangeInclusiveMap<K, V> {
+impl<K, V> IntoIterator for RangeInclusiveMap<K, V>
+where
+    K: Ord + Clone,
+{
     type Item = (RangeInclusive<K>, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -30,11 +30,8 @@ use serde::{
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone, PartialEq, Eq)]
-pub struct RangeInclusiveMap<K, V, StepFnsT = K>
-where
-    K: Eq,
-{
+#[derive(Clone)]
+pub struct RangeInclusiveMap<K, V, StepFnsT = K> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeInclusiveStartWrapper<K>, V>,
@@ -49,6 +46,23 @@ where
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl<K, V> PartialEq for RangeInclusiveMap<K, V, K>
+where
+    K: Eq,
+    V: Eq,
+{
+    fn eq(&self, other: &RangeInclusiveMap<K, V, K>) -> bool {
+        self.btm == other.btm
+    }
+}
+
+impl<K, V> Eq for RangeInclusiveMap<K, V, K>
+where
+    K: Eq,
+    V: Eq,
+{
 }
 
 impl<K, V> RangeInclusiveMap<K, V, K>
@@ -489,8 +503,7 @@ pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeInclusiveStartWrapper<K>, V>,
 }
 
-impl<K, V> IntoIterator for RangeInclusiveMap<K, V> where
-K: Eq,{
+impl<K, V> IntoIterator for RangeInclusiveMap<K, V> {
     type Item = (RangeInclusive<K>, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1,6 +1,7 @@
 use super::range_wrapper::RangeInclusiveStartWrapper;
 use crate::std_ext::*;
 use alloc::collections::BTreeMap;
+use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::marker::PhantomData;
@@ -63,6 +64,28 @@ where
     K: Eq,
     V: Eq,
 {
+}
+
+impl<K, V> PartialOrd for RangeInclusiveMap<K, V, K>
+where
+    K: Ord + PartialOrd,
+    V: Ord + PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RangeInclusiveMap<K, V, K>) -> Option<Ordering> {
+        self.btm.partial_cmp(&other.btm)
+    }
+}
+
+impl<K, V> Ord for RangeInclusiveMap<K, V, K>
+where
+    K: Ord,
+    V: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &RangeInclusiveMap<K, V, K>) -> Ordering {
+        self.btm.cmp(&other.btm)
+    }
 }
 
 impl<K, V> RangeInclusiveMap<K, V, K>

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -30,10 +30,10 @@ use serde::{
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RangeInclusiveMap<K, V, StepFnsT = K>
 where
-    K: Ord + Clone,
+    K: Eq,
 {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
@@ -489,10 +489,8 @@ pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeInclusiveStartWrapper<K>, V>,
 }
 
-impl<K, V> IntoIterator for RangeInclusiveMap<K, V>
-where
-    K: Ord + Clone,
-{
+impl<K, V> IntoIterator for RangeInclusiveMap<K, V> where
+K: Eq,{
     type Item = (RangeInclusive<K>, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -13,17 +13,14 @@ use serde::{
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
 /// See [`RangeInclusiveMap`]'s documentation for more details.
 ///
 /// [`RangeInclusiveMap`]: struct.RangeInclusiveMap.html
-pub struct RangeInclusiveSet<T, StepFnsT = T>
-where
-    T: Eq,
-{
+pub struct RangeInclusiveSet<T, StepFnsT = T> {
     rm: RangeInclusiveMap<T, (), StepFnsT>,
 }
 
@@ -35,6 +32,17 @@ where
         Self::new()
     }
 }
+
+impl<T> PartialEq for RangeInclusiveSet<T, T>
+where
+    T: Eq,
+{
+    fn eq(&self, other: &RangeInclusiveSet<T, T>) -> bool {
+        self.rm == other.rm
+    }
+}
+
+impl<T> Eq for RangeInclusiveSet<T, T> where T: Eq {}
 
 impl<T> RangeInclusiveSet<T, T>
 where
@@ -159,10 +167,7 @@ pub struct IntoIter<T> {
     inner: super::inclusive_map::IntoIter<T, ()>,
 }
 
-impl<T> IntoIterator for RangeInclusiveSet<T>
-where
-    T: Eq,
-{
+impl<T> IntoIterator for RangeInclusiveSet<T> {
     type Item = RangeInclusive<T>;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -36,18 +36,18 @@ where
 
 impl<T> PartialEq for RangeInclusiveSet<T, T>
 where
-    T: Eq,
+    T: Ord + Eq + StepLite,
 {
     fn eq(&self, other: &RangeInclusiveSet<T, T>) -> bool {
         self.rm == other.rm
     }
 }
 
-impl<T> Eq for RangeInclusiveSet<T, T> where T: Eq {}
+impl<T> Eq for RangeInclusiveSet<T, T> where T: Ord + Eq + StepLite {}
 
 impl<T> PartialOrd for RangeInclusiveSet<T, T>
 where
-    T: Ord + PartialOrd,
+    T: Ord + PartialOrd + StepLite,
 {
     #[inline]
     fn partial_cmp(&self, other: &RangeInclusiveSet<T, T>) -> Option<Ordering> {
@@ -57,7 +57,7 @@ where
 
 impl<T> Ord for RangeInclusiveSet<T, T>
 where
-    T: Ord,
+    T: Ord + StepLite,
 {
     #[inline]
     fn cmp(&self, other: &RangeInclusiveSet<T, T>) -> Ordering {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -13,14 +13,17 @@ use serde::{
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
 /// See [`RangeInclusiveMap`]'s documentation for more details.
 ///
 /// [`RangeInclusiveMap`]: struct.RangeInclusiveMap.html
-pub struct RangeInclusiveSet<T, StepFnsT = T> {
+pub struct RangeInclusiveSet<T, StepFnsT = T>
+where
+    T: Ord + Clone,
+{
     rm: RangeInclusiveMap<T, (), StepFnsT>,
 }
 
@@ -156,7 +159,10 @@ pub struct IntoIter<T> {
     inner: super::inclusive_map::IntoIter<T, ()>,
 }
 
-impl<T> IntoIterator for RangeInclusiveSet<T> {
+impl<T> IntoIterator for RangeInclusiveSet<T>
+where
+    T: Ord + Clone,
+{
     type Item = RangeInclusive<T>;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,3 +1,4 @@
+use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::RangeInclusive;
@@ -43,6 +44,26 @@ where
 }
 
 impl<T> Eq for RangeInclusiveSet<T, T> where T: Eq {}
+
+impl<T> PartialOrd for RangeInclusiveSet<T, T>
+where
+    T: Ord + PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RangeInclusiveSet<T, T>) -> Option<Ordering> {
+        self.rm.partial_cmp(&other.rm)
+    }
+}
+
+impl<T> Ord for RangeInclusiveSet<T, T>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &RangeInclusiveSet<T, T>) -> Ordering {
+        self.rm.cmp(&other.rm)
+    }
+}
 
 impl<T> RangeInclusiveSet<T, T>
 where

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -13,7 +13,7 @@ use serde::{
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
 
-#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
@@ -22,7 +22,7 @@ use crate::RangeInclusiveMap;
 /// [`RangeInclusiveMap`]: struct.RangeInclusiveMap.html
 pub struct RangeInclusiveSet<T, StepFnsT = T>
 where
-    T: Ord + Clone,
+    T: Eq,
 {
     rm: RangeInclusiveMap<T, (), StepFnsT>,
 }
@@ -161,7 +161,7 @@ pub struct IntoIter<T> {
 
 impl<T> IntoIterator for RangeInclusiveSet<T>
 where
-    T: Ord + Clone,
+    T: Eq,
 {
     type Item = RangeInclusive<T>;
     type IntoIter = IntoIter<T>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,7 @@
 use super::range_wrapper::RangeStartWrapper;
 use crate::std_ext::*;
 use alloc::collections::BTreeMap;
+use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::Range;
@@ -43,6 +44,28 @@ where
 {
     fn eq(&self, other: &RangeMap<K, V>) -> bool {
         self.btm == other.btm
+    }
+}
+
+impl<K, V> PartialOrd for RangeMap<K, V>
+where
+    K: Ord + PartialOrd,
+    V: Ord + PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RangeMap<K, V>) -> Option<Ordering> {
+        self.btm.partial_cmp(&other.btm)
+    }
+}
+
+impl<K, V> Ord for RangeMap<K, V>
+where
+    K: Ord,
+    V: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &RangeMap<K, V>) -> Ordering {
+        self.btm.cmp(&other.btm)
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -19,10 +19,10 @@ use serde::{
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RangeMap<K, V>
 where
-    K: Ord + Clone,
+    K: Eq,
 {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
@@ -428,7 +428,7 @@ pub struct IntoIter<K, V> {
 
 impl<K, V> IntoIterator for RangeMap<K, V>
 where
-    K: Ord + Clone,
+    K: Eq,
 {
     type Item = (Range<K>, V);
     type IntoIter = IntoIter<K, V>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -19,11 +19,8 @@ use serde::{
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone, PartialEq, Eq)]
-pub struct RangeMap<K, V>
-where
-    K: Eq,
-{
+#[derive(Clone)]
+pub struct RangeMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeStartWrapper<K>, V>,
@@ -37,6 +34,23 @@ where
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl<K, V> PartialEq for RangeMap<K, V>
+where
+    K: Eq,
+    V: Eq,
+{
+    fn eq(&self, other: &RangeMap<K, V>) -> bool {
+        self.btm == other.btm
+    }
+}
+
+impl<K, V> Eq for RangeMap<K, V>
+where
+    K: Eq,
+    V: Eq,
+{
 }
 
 impl<K, V> RangeMap<K, V>
@@ -426,10 +440,7 @@ pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeStartWrapper<K>, V>,
 }
 
-impl<K, V> IntoIterator for RangeMap<K, V>
-where
-    K: Eq,
-{
+impl<K, V> IntoIterator for RangeMap<K, V> {
     type Item = (Range<K>, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/map.rs
+++ b/src/map.rs
@@ -19,8 +19,11 @@ use serde::{
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone)]
-pub struct RangeMap<K, V> {
+#[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
+pub struct RangeMap<K, V>
+where
+    K: Ord + Clone,
+{
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeStartWrapper<K>, V>,
@@ -423,7 +426,10 @@ pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeStartWrapper<K>, V>,
 }
 
-impl<K, V> IntoIterator for RangeMap<K, V> {
+impl<K, V> IntoIterator for RangeMap<K, V>
+where
+    K: Ord + Clone,
+{
     type Item = (Range<K>, V);
     type IntoIter = IntoIter<K, V>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/set.rs
+++ b/src/set.rs
@@ -13,14 +13,17 @@ use serde::{
 
 use crate::RangeMap;
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
 /// See [`RangeMap`]'s documentation for more details.
 ///
 /// [`RangeMap`]: struct.RangeMap.html
-pub struct RangeSet<T> {
+pub struct RangeSet<T>
+where
+    T: Ord + Clone,
+{
     rm: RangeMap<T, ()>,
 }
 
@@ -145,7 +148,10 @@ pub struct IntoIter<T> {
     inner: super::map::IntoIter<T, ()>,
 }
 
-impl<T> IntoIterator for RangeSet<T> {
+impl<T> IntoIterator for RangeSet<T>
+where
+    T: Ord + Clone,
+{
     type Item = Range<T>;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,3 +1,4 @@
+use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::Range;
@@ -43,6 +44,26 @@ where
 }
 
 impl<T> Eq for RangeSet<T> where T: Eq {}
+
+impl<T> PartialOrd for RangeSet<T>
+where
+    T: Ord + PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RangeSet<T>) -> Option<Ordering> {
+        self.rm.partial_cmp(&other.rm)
+    }
+}
+
+impl<T> Ord for RangeSet<T>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &RangeSet<T>) -> Ordering {
+        self.rm.cmp(&other.rm)
+    }
+}
 
 impl<T> RangeSet<T>
 where

--- a/src/set.rs
+++ b/src/set.rs
@@ -13,7 +13,7 @@ use serde::{
 
 use crate::RangeMap;
 
-#[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialEq)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
@@ -22,7 +22,7 @@ use crate::RangeMap;
 /// [`RangeMap`]: struct.RangeMap.html
 pub struct RangeSet<T>
 where
-    T: Ord + Clone,
+    T: Eq,
 {
     rm: RangeMap<T, ()>,
 }
@@ -150,7 +150,7 @@ pub struct IntoIter<T> {
 
 impl<T> IntoIterator for RangeSet<T>
 where
-    T: Ord + Clone,
+    T: Eq,
 {
     type Item = Range<T>;
     type IntoIter = IntoIter<T>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -13,17 +13,14 @@ use serde::{
 
 use crate::RangeMap;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
 /// See [`RangeMap`]'s documentation for more details.
 ///
 /// [`RangeMap`]: struct.RangeMap.html
-pub struct RangeSet<T>
-where
-    T: Eq,
-{
+pub struct RangeSet<T> {
     rm: RangeMap<T, ()>,
 }
 
@@ -35,6 +32,17 @@ where
         RangeSet::new()
     }
 }
+
+impl<T> PartialEq for RangeSet<T>
+where
+    T: Eq,
+{
+    fn eq(&self, other: &RangeSet<T>) -> bool {
+        self.rm == other.rm
+    }
+}
+
+impl<T> Eq for RangeSet<T> where T: Eq {}
 
 impl<T> RangeSet<T>
 where
@@ -148,10 +156,7 @@ pub struct IntoIter<T> {
     inner: super::map::IntoIter<T, ()>,
 }
 
-impl<T> IntoIterator for RangeSet<T>
-where
-    T: Eq,
-{
+impl<T> IntoIterator for RangeSet<T> {
     type Item = Range<T>;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {


### PR DESCRIPTION
Add PartialEq and Eq setups to RangeSet, RangeMap, RangeInclusiveSet and RangeInclusiveMap. This is being added so we can use this library with cosmic_text for AttrList range handling.  If you could get this in a published crate that would help us out tremendously.  This is for #https://github.com/pop-os/cosmic-text/issues/28