### PR TITLE
add clear, len and is_empty

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -173,6 +173,21 @@ where
         }
     }
 
+    /// Clears the map, removing all elements.
+    pub fn clear(&mut self) {
+        self.btm.clear();
+    }
+
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.btm.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.btm.is_empty()
+    }
+
     /// Insert a pair of key range and value into the map.
     ///
     /// If the inserted range partially or completely overlaps any

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -125,6 +125,21 @@ where
         }
     }
 
+    /// Clears the set, removing all elements.
+    pub fn clear(&mut self) {
+        self.rm.clear();
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.rm.len()
+    }
+
+    /// Returns true if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.rm.is_empty()
+    }
+
     /// Insert a range into the set.
     ///
     /// If the inserted range either overlaps or is immediately adjacent

--- a/src/map.rs
+++ b/src/map.rs
@@ -137,6 +137,21 @@ where
         }
     }
 
+    /// Clears the map, removing all elements.
+    pub fn clear(&mut self) {
+        self.btm.clear();
+    }
+
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.btm.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.btm.is_empty()
+    }
+
     /// Insert a pair of key range and value into the map.
     ///
     /// If the inserted range partially or completely overlaps any

--- a/src/set.rs
+++ b/src/set.rs
@@ -103,6 +103,21 @@ where
         }
     }
 
+    /// Clears the set, removing all elements.
+    pub fn clear(&mut self) {
+        self.rm.clear();
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.rm.len()
+    }
+
+    /// Returns true if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.rm.is_empty()
+    }
+
     /// Insert a range into the set.
     ///
     /// If the inserted range either overlaps or is immediately adjacent


### PR DESCRIPTION
I have added a few Default functions that exist within the Btree.

I do think we might also add split_off, Entry, append and retain.

Also would be nice to see remove_entry that returns a removed entry/entries and to change remove to return a value/values. I will make a Issue for these.

this fixes #53 and #44 