### PR TITLE
Make RangeMap and RangeSet generic over a RangeTrait instead of core::ops::Range

### DIFF
--- a/benches/kitchen_sink.rs
+++ b/benches/kitchen_sink.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 fn kitchen_sink(kvs: &[(Range<i32>, bool)]) {
     use rangemap::RangeMap;
 
-    let mut range_map: RangeMap<i32, bool> = RangeMap::new();
+    let mut range_map: RangeMap<Range<i32>, bool> = RangeMap::new();
     // Remove every second range.
     let mut remove = false;
     for (range, value) in kvs {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -62,11 +62,11 @@ where
     }
 }
 
-impl<V> From<RangeMap<u32, V>> for DenseU32RangeMap<V>
+impl<V> From<RangeMap<Range<u32>, V>> for DenseU32RangeMap<V>
 where
     V: Eq + Clone,
 {
-    fn from(range_map: RangeMap<u32, V>) -> Self {
+    fn from(range_map: RangeMap<Range<u32>, V>) -> Self {
         let mut dense = Self::new();
         for (range, value) in range_map.iter() {
             // Convert to inclusive end.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,12 +139,14 @@ pub mod set;
 
 #[cfg(test)]
 mod dense;
+mod range_trait;
 mod range_wrapper;
 mod std_ext;
 
 pub use inclusive_map::RangeInclusiveMap;
 pub use inclusive_set::RangeInclusiveSet;
 pub use map::RangeMap;
+pub use range_trait::RangeTrait;
 pub use set::RangeSet;
 pub use std_ext::{StepFns, StepLite};
 

--- a/src/range_trait.rs
+++ b/src/range_trait.rs
@@ -1,0 +1,48 @@
+use core::ops::Range;
+
+pub trait RangeTrait {
+    type A: Ord;
+    fn start(&self) -> &Self::A;
+    fn end(&self) -> &Self::A;
+    fn set_start(&mut self, new_start: Self::A);
+    fn set_end(&mut self, new_end: Self::A);
+    fn new(start: Self::A, end: Self::A) -> Self;
+    fn contains(&self, item: &Self::A) -> bool {
+        item >= self.start() && item < self.end()
+    }
+    fn overlaps(&self, other: &Self) -> bool {
+        use core::cmp::{max, min};
+        // Strictly less than, because ends are excluded.
+        max(&self.start(), &other.start()) < min(&self.end(), &other.end())
+    }
+    fn touches(&self, other: &Self) -> bool {
+        use core::cmp::{max, min};
+        // Less-than-or-equal-to because if one end is excluded, the other is included.
+        // I.e. the two could be joined into a single range, because they're overlapping
+        // or immediately adjacent.
+        max(&self.start(), &other.start()) <= min(&self.end(), &other.end())
+    }
+}
+
+// Implement for all ranges
+impl<T> RangeTrait for Range<T>
+where
+    T: Ord,
+{
+    type A = T;
+    fn new(start: Self::A, end: Self::A) -> Self {
+        start..end
+    }
+    fn start(&self) -> &Self::A {
+        &self.start
+    }
+    fn end(&self) -> &Self::A {
+        &self.end
+    }
+    fn set_start(&mut self, new_start: Self::A) {
+        self.start = new_start;
+    }
+    fn set_end(&mut self, new_end: Self::A) {
+        self.start = new_end;
+    }
+}

--- a/src/range_trait.rs
+++ b/src/range_trait.rs
@@ -43,6 +43,6 @@ where
         self.start = new_start;
     }
     fn set_end(&mut self, new_end: Self::A) {
-        self.start = new_end;
+        self.end = new_end;
     }
 }

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -11,47 +11,59 @@
 // inner range!
 
 use core::cmp::Ordering;
-use core::ops::{Range, RangeInclusive};
+use core::ops::RangeInclusive;
+
+use crate::RangeTrait;
 
 //
 // Range start wrapper
 //
 
-#[derive(Eq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct RangeStartWrapper<T> {
-    pub range: Range<T>,
+    pub range: T,
 }
 
 impl<T> RangeStartWrapper<T> {
-    pub fn new(range: Range<T>) -> RangeStartWrapper<T> {
+    pub fn new(range: T) -> RangeStartWrapper<T> {
         RangeStartWrapper { range }
     }
 }
 
-impl<T> PartialEq for RangeStartWrapper<T>
+impl<T, I> PartialEq for RangeStartWrapper<T>
 where
-    T: PartialEq,
+    T: RangeTrait<A = I>,
+    I: PartialEq,
 {
     fn eq(&self, other: &RangeStartWrapper<T>) -> bool {
-        self.range.start == other.range.start
+        self.range.start() == other.range.start()
     }
 }
 
-impl<T> Ord for RangeStartWrapper<T>
+impl<T, I> Eq for RangeStartWrapper<T>
 where
-    T: Ord,
+    T: RangeTrait<A = I>,
+    I: Eq,
+{
+}
+
+impl<T, I> Ord for RangeStartWrapper<T>
+where
+    T: RangeTrait<A = I>,
+    I: Ord,
 {
     fn cmp(&self, other: &RangeStartWrapper<T>) -> Ordering {
-        self.range.start.cmp(&other.range.start)
+        self.range.start().cmp(&other.range.start())
     }
 }
 
-impl<T> PartialOrd for RangeStartWrapper<T>
+impl<T, I> PartialOrd for RangeStartWrapper<T>
 where
-    T: PartialOrd,
+    T: RangeTrait<A = I>,
+    I: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeStartWrapper<T>) -> Option<Ordering> {
-        self.range.start.partial_cmp(&other.range.start)
+        self.range.start().partial_cmp(&other.range.start())
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,18 +1,9 @@
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
-use core::ops::Range;
 use core::prelude::v1::*;
 
-#[cfg(feature = "serde1")]
-use core::marker::PhantomData;
-#[cfg(feature = "serde1")]
-use serde::{
-    de::{Deserialize, Deserializer, SeqAccess, Visitor},
-    ser::{Serialize, Serializer},
-};
-
-use crate::RangeMap;
+use crate::{RangeMap, RangeTrait};
 
 #[derive(Clone)]
 /// A set whose items are stored as (half-open) ranges bounded
@@ -25,29 +16,37 @@ pub struct RangeSet<T> {
     rm: RangeMap<T, ()>,
 }
 
-impl<T> Default for RangeSet<T>
+impl<T, I> Default for RangeSet<T>
 where
-    T: Ord + Clone,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
     fn default() -> Self {
         RangeSet::new()
     }
 }
 
-impl<T> PartialEq for RangeSet<T>
+impl<T, I> PartialEq for RangeSet<T>
 where
-    T: PartialEq,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
     fn eq(&self, other: &RangeSet<T>) -> bool {
         self.rm == other.rm
     }
 }
 
-impl<T> Eq for RangeSet<T> where T: Eq {}
-
-impl<T> PartialOrd for RangeSet<T>
+impl<T, I> Eq for RangeSet<T>
 where
-    T: PartialOrd,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
+{
+}
+
+impl<T, I> PartialOrd for RangeSet<T>
+where
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
     #[inline]
     fn partial_cmp(&self, other: &RangeSet<T>) -> Option<Ordering> {
@@ -55,9 +54,10 @@ where
     }
 }
 
-impl<T> Ord for RangeSet<T>
+impl<T, I> Ord for RangeSet<T>
 where
-    T: Ord,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
     #[inline]
     fn cmp(&self, other: &RangeSet<T>) -> Ordering {
@@ -65,9 +65,10 @@ where
     }
 }
 
-impl<T> RangeSet<T>
+impl<T, I> RangeSet<T>
 where
-    T: Ord + Clone,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
     /// Makes a new empty `RangeSet`.
     #[cfg(feature = "const_fn")]
@@ -86,12 +87,12 @@ where
     }
 
     /// Returns a reference to the range covering the given key, if any.
-    pub fn get(&self, value: &T) -> Option<&Range<T>> {
+    pub fn get(&self, value: &I) -> Option<&T> {
         self.rm.get_key_value(value).map(|(range, _)| range)
     }
 
     /// Returns `true` if any range in the set covers the specified value.
-    pub fn contains(&self, value: &T) -> bool {
+    pub fn contains(&self, value: &I) -> bool {
         self.rm.contains_key(value)
     }
 
@@ -112,7 +113,7 @@ where
     /// # Panics
     ///
     /// Panics if range `start >= end`.
-    pub fn insert(&mut self, range: Range<T>) {
+    pub fn insert(&mut self, range: T) {
         self.rm.insert(range, ());
     }
 
@@ -125,7 +126,7 @@ where
     /// # Panics
     ///
     /// Panics if range `start >= end`.
-    pub fn remove(&mut self, range: Range<T>) {
+    pub fn remove(&mut self, range: T) {
         self.rm.remove(range);
     }
 
@@ -138,7 +139,7 @@ where
     /// empty gap will be returned.
     ///
     /// The iterator element type is `Range<T>`.
-    pub fn gaps<'a>(&'a self, outer_range: &'a Range<T>) -> Gaps<'a, T> {
+    pub fn gaps<'a>(&'a self, outer_range: &'a T) -> Gaps<'a, T, I> {
         Gaps {
             inner: self.rm.gaps(outer_range),
         }
@@ -156,9 +157,9 @@ pub struct Iter<'a, T> {
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
-    type Item = &'a Range<T>;
+    type Item = &'a T;
 
-    fn next(&mut self) -> Option<&'a Range<T>> {
+    fn next(&mut self) -> Option<&'a T> {
         self.inner.next().map(|(range, _)| range)
     }
 
@@ -178,7 +179,7 @@ pub struct IntoIter<T> {
 }
 
 impl<T> IntoIterator for RangeSet<T> {
-    type Item = Range<T>;
+    type Item = T;
     type IntoIter = IntoIter<T>;
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
@@ -188,8 +189,8 @@ impl<T> IntoIterator for RangeSet<T> {
 }
 
 impl<T> Iterator for IntoIter<T> {
-    type Item = Range<T>;
-    fn next(&mut self) -> Option<Range<T>> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
         self.inner.next().map(|(range, _)| range)
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -200,102 +201,37 @@ impl<T> Iterator for IntoIter<T> {
 // We can't just derive this automatically, because that would
 // expose irrelevant (and private) implementation details.
 // Instead implement it in the same way that the underlying BTreeSet does.
-impl<T: Debug> Debug for RangeSet<T>
+impl<T, I> Debug for RangeSet<T>
 where
-    T: Ord + Clone,
+    T: RangeTrait<A = I> + Clone + Debug,
+    I: Clone + Ord,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
 }
 
-impl<T> FromIterator<Range<T>> for RangeSet<T>
+impl<T, I> FromIterator<T> for RangeSet<T>
 where
-    T: Ord + Clone,
+    T: RangeTrait<A = I> + Clone,
+    I: Clone + Ord,
 {
-    fn from_iter<I: IntoIterator<Item = Range<T>>>(iter: I) -> Self {
+    fn from_iter<M: IntoIterator<Item = T>>(iter: M) -> Self {
         let mut range_set = RangeSet::new();
         range_set.extend(iter);
         range_set
     }
 }
 
-impl<T> Extend<Range<T>> for RangeSet<T>
+impl<T, I> Extend<T> for RangeSet<T>
 where
-    T: Ord + Clone,
+    T: RangeTrait<A = I> + Clone,
+    I: Clone + Ord,
 {
-    fn extend<I: IntoIterator<Item = Range<T>>>(&mut self, iter: I) {
+    fn extend<M: IntoIterator<Item = T>>(&mut self, iter: M) {
         iter.into_iter().for_each(move |range| {
             self.insert(range);
         })
-    }
-}
-
-#[cfg(feature = "serde1")]
-impl<T> Serialize for RangeSet<T>
-where
-    T: Ord + Clone + Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(self.rm.btm.len()))?;
-        for range in self.iter() {
-            seq.serialize_element(&(&range.start, &range.end))?;
-        }
-        seq.end()
-    }
-}
-
-#[cfg(feature = "serde1")]
-impl<'de, T> Deserialize<'de> for RangeSet<T>
-where
-    T: Ord + Clone + Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(RangeSetVisitor::new())
-    }
-}
-
-#[cfg(feature = "serde1")]
-struct RangeSetVisitor<T> {
-    marker: PhantomData<fn() -> RangeSet<T>>,
-}
-
-#[cfg(feature = "serde1")]
-impl<T> RangeSetVisitor<T> {
-    fn new() -> Self {
-        RangeSetVisitor {
-            marker: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "serde1")]
-impl<'de, T> Visitor<'de> for RangeSetVisitor<T>
-where
-    T: Ord + Clone + Deserialize<'de>,
-{
-    type Value = RangeSet<T>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("RangeSet")
-    }
-
-    fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
-    where
-        A: SeqAccess<'de>,
-    {
-        let mut range_set = RangeSet::new();
-        while let Some((start, end)) = access.next_element()? {
-            range_set.insert(start..end);
-        }
-        Ok(range_set)
     }
 }
 
@@ -305,18 +241,24 @@ where
 /// documentation for more.
 ///
 /// [`gaps`]: RangeSet::gaps
-pub struct Gaps<'a, T> {
-    inner: crate::map::Gaps<'a, T, ()>,
+pub struct Gaps<'a, T, I> {
+    inner: crate::map::Gaps<'a, T, I, ()>,
 }
 
 // `Gaps` is always fused. (See definition of `next` below.)
-impl<'a, T> core::iter::FusedIterator for Gaps<'a, T> where T: Ord + Clone {}
-
-impl<'a, T> Iterator for Gaps<'a, T>
+impl<'a, T, I> core::iter::FusedIterator for Gaps<'a, T, I>
 where
-    T: Ord + Clone,
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
 {
-    type Item = Range<T>;
+}
+
+impl<'a, T, I> Iterator for Gaps<'a, T, I>
+where
+    T: Clone + RangeTrait<A = I>,
+    I: Ord + Clone,
+{
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -327,36 +269,38 @@ where
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+    use core::ops::Range;
 
     trait RangeSetExt<T> {
-        fn to_vec(&self) -> Vec<Range<T>>;
+        fn to_vec(&self) -> Vec<T>;
     }
 
-    impl<T> RangeSetExt<T> for RangeSet<T>
+    impl<T, I> RangeSetExt<T> for RangeSet<T>
     where
-        T: Ord + Clone,
+        T: RangeTrait<A = I> + Clone,
+        I: Clone + Ord,
     {
-        fn to_vec(&self) -> Vec<Range<T>> {
+        fn to_vec(&self) -> Vec<T> {
             self.iter().cloned().collect()
         }
     }
 
     #[test]
     fn empty_set_is_empty() {
-        let range_set: RangeSet<u32> = RangeSet::new();
+        let range_set: RangeSet<Range<u32>> = RangeSet::new();
         assert_eq!(range_set.to_vec(), vec![]);
     }
 
     #[test]
     fn insert_into_empty_map() {
-        let mut range_set: RangeSet<u32> = RangeSet::new();
+        let mut range_set: RangeSet<Range<u32>> = RangeSet::new();
         range_set.insert(0..50);
         assert_eq!(range_set.to_vec(), vec![0..50]);
     }
 
     #[test]
     fn remove_partially_overlapping() {
-        let mut range_set: RangeSet<u32> = RangeSet::new();
+        let mut range_set: RangeSet<Range<u32>> = RangeSet::new();
         range_set.insert(0..50);
         range_set.remove(25..75);
         assert_eq!(range_set.to_vec(), vec![0..25]);
@@ -364,7 +308,7 @@ mod tests {
 
     #[test]
     fn gaps_between_items_floating_inside_outer_range() {
-        let mut range_set: RangeSet<u32> = RangeSet::new();
+        let mut range_set: RangeSet<Range<u32>> = RangeSet::new();
         // 0 1 2 3 4 5 6 7 8 9
         // ◌ ◌ ◌ ◌ ◌ ●-◌ ◌ ◌ ◌
         range_set.insert(5..6);
@@ -391,7 +335,7 @@ mod tests {
 
     #[test]
     fn set_debug_repr_looks_right() {
-        let mut set: RangeSet<u32> = RangeSet::new();
+        let mut set: RangeSet<Range<u32>> = RangeSet::new();
 
         // Empty
         assert_eq!(format!("{:?}", set), "{}");
@@ -404,32 +348,5 @@ mod tests {
         set.insert(7..8);
         set.insert(10..11);
         assert_eq!(format!("{:?}", set), "{2..5, 7..8, 10..11}");
-    }
-
-    // impl Serialize
-
-    #[cfg(feature = "serde1")]
-    #[test]
-    fn serialization() {
-        let mut range_set: RangeSet<u32> = RangeSet::new();
-        // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◆---◇ ◌ ◌ ◌ ◌ ◌ ◌
-        range_set.insert(1..3);
-        // 0 1 2 3 4 5 6 7 8 9
-        // ◌ ◌ ◌ ◌ ◌ ◆---◇ ◌ ◌
-        range_set.insert(5..7);
-        let output = serde_json::to_string(&range_set).expect("Failed to serialize");
-        assert_eq!(output, "[[1,3],[5,7]]");
-    }
-
-    // impl Deserialize
-
-    #[cfg(feature = "serde1")]
-    #[test]
-    fn deserialization() {
-        let input = "[[1,3],[5,7]]";
-        let range_set: RangeSet<u32> = serde_json::from_str(input).expect("Failed to deserialize");
-        let reserialized = serde_json::to_string(&range_set).expect("Failed to re-serialize");
-        assert_eq!(reserialized, input);
     }
 }


### PR DESCRIPTION
#### This is my attempt at fixing #56 

### Important caveats:
- I deleted serde impls because they scared me as I haven't got much experience with serde impls yet
- I didn't touch `RangeMapInclusive` or `RangeSetInclusive` but I imagine the changover process would be roughly the same. I wanted to see what you thought before I went to far (also I don't need Inclusive for my usecases lol shh)

### Some things worth noting:
- Some comments may have been invalidated, I didn't read any of them -_-
- I added `impl<T> RangeTrait for Range<T>` which is nice
- I made a new trait RangeTrait for the needed operations but there may exist a more standard version of RangeTrait somewhere rather than making our own
- Not sure whether we should keep RangeExt separate from RangeTrait or merge them
- Soooo many Bounds everywhere which makes me nervous that I over-bounded something somewhere, (I wish module-level bounds were a thing)

### Questions I have
- What do ya think?
- Is the extra complexity of using a trait vs just using `Range`s worth it? And if so I am happy to overhall the Inclusive variants to match.
- What do you think about using an associated type in the `RangeTrait` vs using a `RangeTrait<I>`? I went with the associated type version but not for any particular reason.
- Since you're in post v1.0 would this count as a breaking change?