### PR TITLE
Make `const_fn` feature work again

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -126,6 +126,7 @@ where
     ///
     /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
     /// for details about that stabilization process.
+    #[cfg(not(feature = "const_fn"))]
     pub fn new_with_step_fns() -> Self {
         Self {
             btm: BTreeMap::new(),
@@ -133,6 +134,13 @@ where
         }
     }
 
+    #[cfg(feature = "const_fn")]
+    pub const fn new_with_step_fns() -> Self {
+        Self {
+            btm: BTreeMap::new(),
+            _phantom: PhantomData,
+        }
+    }
     /// Returns a reference to the value corresponding to the given key,
     /// if the key is covered by any range in the map.
     pub fn get(&self, key: &K) -> Option<&V> {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -101,7 +101,15 @@ where
     ///
     /// See [this issue](https://github.com/rust-lang/rust/issues/42168)
     /// for details about that stabilization process.
+    #[cfg(not(feature = "const_fn"))]
     pub fn new_with_step_fns() -> Self {
+        Self {
+            rm: RangeInclusiveMap::new_with_step_fns(),
+        }
+    }
+
+    #[cfg(feature = "const_fn")]
+    pub const fn new_with_step_fns() -> Self {
         Self {
             rm: RangeInclusiveMap::new_with_step_fns(),
         }


### PR DESCRIPTION
Commit 2047d38 accidentally broke the `const_fn` feature, as the constructors for `RangeInclusiveMap::new()` and `RangeInclusiveSet::new()` didn't include a corresponding `const fn` version. This PR restores that functionality.