### PR TITLE
Add `overlapping` method to `RangeMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### (unreleased) (2023-01-??)
+
+- **Features**:
+    - Add `overlapping` method to `RangeMap`, which returns an iterator over all stored range/value pairs that are completely or partially overlapped by a given range.
+
+
 ### v1.2.0 (2022-12-27)
 
 - **Features**:

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -1,7 +1,22 @@
 // Wrappers to allow storing (and sorting/searching)
 // ranges as the keys of a `BTreeMap`.
 //
-// We can do this because we maintain the invariants
+// This wraps the range in two layers: one that lets us
+// order ranges by their start (`RangeStartWrapper`),
+// and then within that, one that lets us order them by
+// their end (`RangeEndWrapper`). Ordinarily we'll use
+// the former, but there are a couple of cases where we
+// want to be able to do the latter for performance/convenience.
+//
+// This is made possible by a sneaky `Borrow` implementation
+// which skirts the law about the borrowed representation
+// having identical implementations of `Ord` etc., but shouldn't
+// be a problem in practice because users of the crate can't
+// access these special wrappers, and we are careful to uphold
+// invariants that prevent observing any states where the
+// differing implementations would produce different results.
+//
+// Specifically, we maintain the invariants
 // that the order of range starts is the same as the order
 // of range ends, and that no two stored ranges have the
 // same start or end as each other.
@@ -17,14 +32,16 @@ use core::ops::{Range, RangeInclusive};
 // Range start wrapper
 //
 
-#[derive(Eq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct RangeStartWrapper<T> {
-    pub range: Range<T>,
+    pub range_end_wrapper: RangeEndWrapper<T>,
 }
 
 impl<T> RangeStartWrapper<T> {
     pub fn new(range: Range<T>) -> RangeStartWrapper<T> {
-        RangeStartWrapper { range }
+        RangeStartWrapper {
+            range_end_wrapper: RangeEndWrapper::new(range),
+        }
     }
 }
 
@@ -33,16 +50,21 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeStartWrapper<T>) -> bool {
-        self.range.start == other.range.start
+        self.range_end_wrapper.range.start == other.range_end_wrapper.range.start
     }
 }
+
+impl<T> Eq for RangeStartWrapper<T> where T: Eq {}
 
 impl<T> Ord for RangeStartWrapper<T>
 where
     T: Ord,
 {
     fn cmp(&self, other: &RangeStartWrapper<T>) -> Ordering {
-        self.range.start.cmp(&other.range.start)
+        self.range_end_wrapper
+            .range
+            .start
+            .cmp(&other.range_end_wrapper.range.start)
     }
 }
 
@@ -51,7 +73,60 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeStartWrapper<T>) -> Option<Ordering> {
-        self.range.start.partial_cmp(&other.range.start)
+        self.range_end_wrapper
+            .range
+            .start
+            .partial_cmp(&other.range_end_wrapper.range.start)
+    }
+}
+
+impl<T> core::borrow::Borrow<RangeEndWrapper<T>> for RangeStartWrapper<T> {
+    fn borrow(&self) -> &RangeEndWrapper<T> {
+        &self.range_end_wrapper
+    }
+}
+
+//
+// Range end wrapper
+//
+
+#[derive(Debug, Clone)]
+pub struct RangeEndWrapper<T> {
+    pub range: Range<T>,
+}
+
+impl<T> RangeEndWrapper<T> {
+    pub fn new(range: Range<T>) -> RangeEndWrapper<T> {
+        RangeEndWrapper { range }
+    }
+}
+
+impl<T> PartialEq for RangeEndWrapper<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &RangeEndWrapper<T>) -> bool {
+        self.range.end == other.range.end
+    }
+}
+
+impl<T> Eq for RangeEndWrapper<T> where T: Eq {}
+
+impl<T> Ord for RangeEndWrapper<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &RangeEndWrapper<T>) -> Ordering {
+        self.range.end.cmp(&other.range.end)
+    }
+}
+
+impl<T> PartialOrd for RangeEndWrapper<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &RangeEndWrapper<T>) -> Option<Ordering> {
+        self.range.end.partial_cmp(&other.range.end)
     }
 }
 


### PR DESCRIPTION
Returns an iterator over all stored range/value pairs that are
completely or partially overlapped by a given range.

I haven't yet added this to the all the other collection types;
want to get some feedback on this one first, and probably add
some extra testing -- maybe integrate with existing fuzz tests.