### PR TITLE
Add 'overlapping' and 'overlaps' methods to all container types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### (unreleased) (2023-01-??)
 
 - **Features**:
-    - Add `overlapping` method to `RangeMap`, which returns an iterator over all stored range/value pairs that are completely or partially overlapped by a given range.
+    - Add `overlapping` method to all collection types, which returns an iterator over all stored entries that completely or partially overlap a given range.
+    - Add `overlaps` convenience method to all collection types, which returns whether any stored range completely or partially overlaps a given range.
+    - Credit to [Rua](https://github.com/Rua) for the original implementation of these new methods. (Unfortunately I couldn't use their code directly because I made other incompatible changes.) Thanks also to [rumpuslabs](https://github.com/rumpuslabs) for their engagement.
 
 
 ### v1.2.0 (2022-12-27)

--- a/fuzz/fuzz_targets/rangemap_gaps.rs
+++ b/fuzz/fuzz_targets/rangemap_gaps.rs
@@ -54,18 +54,11 @@ fuzz_target!(|input: Input| {
 
     // Check that the combination of gaps and keys fills the entire outer range.
     let gaps: Vec<Range<u8>> = map.gaps(&outer_range).collect();
-    // TODO: Replace the filtering and mapping with a `range` iterator
-    // on the map itself.
     let mut keys: Vec<Range<u8>> = map
-        .into_iter()
-        .map(|(k, _v)| k)
-        .filter(|Range { start, end }| {
-            // Reject anything with zero of its width inside the outer range.
-            *end > outer_range.start && *start < outer_range.end
-        })
-        .map(|Range { start, end }| {
+        .overlapping(&outer_range)
+        .map(|(Range { start, end }, _key)| {
             // Truncate anything straddling either edge.
-            u8::max(start, outer_range.start)..u8::min(end, outer_range.end)
+            u8::max(*start, outer_range.start)..u8::min(*end, outer_range.end)
         })
         .filter(|range| {
             // Reject anything that is now empty after being truncated.

--- a/fuzz/fuzz_targets/rangemap_inclusive_gaps.rs
+++ b/fuzz/fuzz_targets/rangemap_inclusive_gaps.rs
@@ -53,16 +53,9 @@ fuzz_target!(|input: Input| {
 
     // Check that the combination of gaps and keys fills the entire outer range.
     let gaps: Vec<RangeInclusive<u8>> = map.gaps(&outer_range).collect();
-    // TODO: Replace the filtering and mapping with a `range` iterator
-    // on the map itself.
     let mut keys: Vec<RangeInclusive<u8>> = map
-        .into_iter()
-        .map(|(k, _v)| k)
-        .filter(|range| {
-            // Reject anything with zero of its width inside the outer range.
-            *range.end() >= *outer_range.start() && *range.start() <= *outer_range.end()
-        })
-        .map(|range| {
+        .overlapping(&outer_range)
+        .map(|(range, _value)| {
             // Truncate anything straddling either edge.
             u8::max(*range.start(), *outer_range.start())
                 ..=u8::min(*range.end(), *outer_range.end())

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -542,6 +542,12 @@ where
             btm_range_iter,
         }
     }
+
+    /// Returns `true` if any range in the map completely or partially
+    /// overlaps the given range.
+    pub fn overlaps(&self, range: &RangeInclusive<K>) -> bool {
+        self.overlapping(range).next().is_some()
+    }
 }
 
 /// An iterator over the entries of a `RangeInclusiveMap`, ordered by key range.

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1,11 +1,12 @@
 use super::range_wrapper::RangeInclusiveStartWrapper;
+use crate::range_wrapper::RangeInclusiveEndWrapper;
 use crate::std_ext::*;
 use alloc::collections::BTreeMap;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::marker::PhantomData;
-use core::ops::RangeInclusive;
+use core::ops::{RangeFrom, RangeInclusive};
 use core::prelude::v1::*;
 
 #[cfg(feature = "serde1")]
@@ -161,9 +162,9 @@ where
             .filter(|(range_start_wrapper, _value)| {
                 // Does the only candidate range contain
                 // the requested key?
-                range_start_wrapper.range.contains(key)
+                range_start_wrapper.end_wrapper.range.contains(key)
             })
-            .map(|(range_start_wrapper, value)| (&range_start_wrapper.range, value))
+            .map(|(range_start_wrapper, value)| (&range_start_wrapper.end_wrapper.range, value))
     }
 
     /// Returns `true` if any range in the map covers the specified key.
@@ -237,7 +238,10 @@ where
         // if both of the above cases exist.
         let mut candidates = self
             .btm
-            .range((Bound::Unbounded, Bound::Included(&new_range_start_wrapper)))
+            .range::<RangeInclusiveStartWrapper<K>, (
+                Bound<&RangeInclusiveStartWrapper<K>>,
+                Bound<&RangeInclusiveStartWrapper<K>>,
+            )>((Bound::Unbounded, Bound::Included(&new_range_start_wrapper)))
             .rev()
             .take(2)
             .filter(|(stored_range_start_wrapper, _stored_value)| {
@@ -246,8 +250,9 @@ where
                 // (Remember that it might actually cover the _whole_
                 // range to insert and then some.)
                 stored_range_start_wrapper
+                    .end_wrapper
                     .range
-                    .touches::<StepFnsT>(&new_range_start_wrapper.range)
+                    .touches::<StepFnsT>(&new_range_start_wrapper.end_wrapper.range)
             });
         if let Some(mut candidate) = candidates.next() {
             // Or the one before it if both cases described above exist.
@@ -259,7 +264,7 @@ where
             self.adjust_touching_ranges_for_insert(
                 stored_range_start_wrapper,
                 stored_value,
-                &mut new_range_start_wrapper.range,
+                &mut new_range_start_wrapper.end_wrapper.range,
                 &new_value,
             );
         }
@@ -275,13 +280,16 @@ where
         //
         // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeInclusiveStartWrapper<T>`
         // and use that to search here, to avoid constructing another `RangeInclusiveStartWrapper`.
-        let second_last_possible_start = new_range_start_wrapper.range.end().clone();
+        let second_last_possible_start = new_range_start_wrapper.end_wrapper.range.end().clone();
         let second_last_possible_start = RangeInclusiveStartWrapper::new(
             second_last_possible_start.clone()..=second_last_possible_start,
         );
         while let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
-            .range((
+            .range::<RangeInclusiveStartWrapper<K>, (
+                Bound<&RangeInclusiveStartWrapper<K>>,
+                Bound<&RangeInclusiveStartWrapper<K>>,
+            )>((
                 Bound::Included(&new_range_start_wrapper),
                 // We would use something like `Bound::Included(&last_possible_start)`,
                 // but making `last_possible_start` might cause arithmetic overflow;
@@ -294,10 +302,10 @@ where
             // end of the subset of stored ranges we want to consider,
             // in part because we use `Bound::Unbounded` above.
             // (See comments up there, and in the individual cases below.)
-            let stored_start = stored_range_start_wrapper.range.start();
-            if *stored_start > *second_last_possible_start.range.start() {
+            let stored_start = stored_range_start_wrapper.end_wrapper.range.start();
+            if *stored_start > *second_last_possible_start.end_wrapper.range.start() {
                 let latest_possible_start =
-                    StepFnsT::add_one(second_last_possible_start.range.start());
+                    StepFnsT::add_one(second_last_possible_start.end_wrapper.range.start());
                 if *stored_start > latest_possible_start {
                     // We're beyond the last stored range that could be relevant.
                     // Avoid wasting time on irrelevant ranges, or even worse, looping forever.
@@ -323,7 +331,7 @@ where
             self.adjust_touching_ranges_for_insert(
                 stored_range_start_wrapper,
                 stored_value,
-                &mut new_range_start_wrapper.range,
+                &mut new_range_start_wrapper.end_wrapper.range,
                 &new_value,
             );
         }
@@ -356,7 +364,7 @@ where
 
         let range_start_wrapper: RangeInclusiveStartWrapper<K> =
             RangeInclusiveStartWrapper::new(range);
-        let range = &range_start_wrapper.range;
+        let range = &range_start_wrapper.end_wrapper.range;
 
         // Is there a stored range overlapping the start of
         // the range to insert?
@@ -365,12 +373,15 @@ where
         // whose start is less than or equal to the start of the range to insert.
         if let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
-            .range((Bound::Unbounded, Bound::Included(&range_start_wrapper)))
+            .range::<RangeInclusiveStartWrapper<K>, (
+                Bound<&RangeInclusiveStartWrapper<K>>,
+                Bound<&RangeInclusiveStartWrapper<K>>,
+            )>((Bound::Unbounded, Bound::Included(&range_start_wrapper)))
             .next_back()
             .filter(|(stored_range_start_wrapper, _stored_value)| {
                 // Does the only candidate range overlap
                 // the range to insert?
-                stored_range_start_wrapper.range.overlaps(range)
+                stored_range_start_wrapper.end_wrapper.range.overlaps(range)
             })
             .map(|(stored_range_start_wrapper, stored_value)| {
                 (stored_range_start_wrapper.clone(), stored_value.clone())
@@ -395,7 +406,10 @@ where
             RangeInclusiveStartWrapper::new(range.end().clone()..=range.end().clone());
         while let Some((stored_range_start_wrapper, stored_value)) = self
             .btm
-            .range((
+            .range::<RangeInclusiveStartWrapper<K>, (
+                Bound<&RangeInclusiveStartWrapper<K>>,
+                Bound<&RangeInclusiveStartWrapper<K>>,
+            )>((
                 Bound::Excluded(&range_start_wrapper),
                 Bound::Included(&new_range_end_as_start),
             ))
@@ -428,34 +442,41 @@ where
             // This means that no matter how big or where the stored range is,
             // we will expand the new range's bounds to subsume it,
             // and then delete the stored range.
-            let new_start =
-                min(new_range.start(), stored_range_start_wrapper.range.start()).clone();
-            let new_end = max(new_range.end(), stored_range_start_wrapper.range.end()).clone();
+            let new_start = min(
+                new_range.start(),
+                stored_range_start_wrapper.end_wrapper.range.start(),
+            )
+            .clone();
+            let new_end = max(
+                new_range.end(),
+                stored_range_start_wrapper.end_wrapper.range.end(),
+            )
+            .clone();
             *new_range = new_start..=new_end;
             self.btm.remove(&stored_range_start_wrapper);
         } else {
             // The ranges have different values.
-            if new_range.overlaps(&stored_range_start_wrapper.range) {
+            if new_range.overlaps(&stored_range_start_wrapper.end_wrapper.range) {
                 // The ranges overlap. This is a little bit more complicated.
                 // Delete the stored range, and then add back between
                 // 0 and 2 subranges at the ends of the range to insert.
                 self.btm.remove(&stored_range_start_wrapper);
-                if stored_range_start_wrapper.range.start() < new_range.start() {
+                if stored_range_start_wrapper.end_wrapper.range.start() < new_range.start() {
                     // Insert the piece left of the range to insert.
                     self.btm.insert(
                         RangeInclusiveStartWrapper::new(
-                            stored_range_start_wrapper.range.start().clone()
+                            stored_range_start_wrapper.end_wrapper.range.start().clone()
                                 ..=StepFnsT::sub_one(new_range.start()),
                         ),
                         stored_value.clone(),
                     );
                 }
-                if stored_range_start_wrapper.range.end() > new_range.end() {
+                if stored_range_start_wrapper.end_wrapper.range.end() > new_range.end() {
                     // Insert the piece right of the range to insert.
                     self.btm.insert(
                         RangeInclusiveStartWrapper::new(
                             StepFnsT::add_one(new_range.end())
-                                ..=stored_range_start_wrapper.range.end().clone(),
+                                ..=stored_range_start_wrapper.end_wrapper.range.end().clone(),
                         ),
                         stored_value,
                     );
@@ -476,7 +497,7 @@ where
         // Delete the stored range, and then add back between
         // 0 and 2 subranges at the ends of the range to insert.
         self.btm.remove(&stored_range_start_wrapper);
-        let stored_range = stored_range_start_wrapper.range;
+        let stored_range = stored_range_start_wrapper.end_wrapper.range;
         if stored_range.start() < range_to_remove.start() {
             // Insert the piece left of the range to insert.
             self.btm.insert(
@@ -514,6 +535,24 @@ where
             _phantom: PhantomData,
         }
     }
+
+    /// Gets an iterator over all the stored ranges that are
+    /// either partially or completely overlapped by the given range.
+    pub fn overlapping<'a>(&'a self, range: &'a RangeInclusive<K>) -> Overlapping<K, V> {
+        // Find the first matching stored range by its _end_,
+        // using sneaky layering and `Borrow` implementation. (See `range_wrappers` module.)
+        let start_sliver =
+            RangeInclusiveEndWrapper::new(range.start().clone()..=range.start().clone());
+        let btm_range_iter = self
+            .btm
+            .range::<RangeInclusiveEndWrapper<K>, RangeFrom<&RangeInclusiveEndWrapper<K>>>(
+                &start_sliver..,
+            );
+        Overlapping {
+            query_range: range,
+            btm_range_iter,
+        }
+    }
 }
 
 /// An iterator over the entries of a `RangeInclusiveMap`, ordered by key range.
@@ -536,7 +575,9 @@ where
     type Item = (&'a RangeInclusive<K>, &'a V);
 
     fn next(&mut self) -> Option<(&'a RangeInclusive<K>, &'a V)> {
-        self.inner.next().map(|(by_start, v)| (&by_start.range, v))
+        self.inner
+            .next()
+            .map(|(by_start, v)| (&by_start.end_wrapper.range, v))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -569,7 +610,9 @@ impl<K, V> IntoIterator for RangeInclusiveMap<K, V> {
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (RangeInclusive<K>, V);
     fn next(&mut self) -> Option<(RangeInclusive<K>, V)> {
-        self.inner.next().map(|(by_start, v)| (by_start.range, v))
+        self.inner
+            .next()
+            .map(|(by_start, v)| (by_start.end_wrapper.range, v))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
@@ -727,7 +770,7 @@ where
         }
 
         for item in &mut self.keys {
-            let range = &item.range;
+            let range = &item.end_wrapper.range;
             if *range.end() < self.candidate_start {
                 // We're already completely past it; ignore it.
             } else if *range.start() <= self.candidate_start {
@@ -760,6 +803,46 @@ where
         if self.candidate_start <= *self.outer_range.end() {
             // There's a gap at the end!
             Some(self.candidate_start.clone()..=self.outer_range.end().clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// An iterator over all stored ranges partially or completely
+/// overlapped by a given range.
+///
+/// The iterator element type is `(&'a RangeInclusive<K>, &'a V)`.
+///
+/// This `struct` is created by the [`overlapping`] method on [`RangeInclusiveMap`]. See its
+/// documentation for more.
+///
+/// [`overlapping`]: RangeInclusiveMap::overlapping
+pub struct Overlapping<'a, K, V> {
+    query_range: &'a RangeInclusive<K>,
+    btm_range_iter: alloc::collections::btree_map::Range<'a, RangeInclusiveStartWrapper<K>, V>,
+}
+
+// `Overlapping` is always fused. (See definition of `next` below.)
+impl<'a, K, V> core::iter::FusedIterator for Overlapping<'a, K, V> where K: Ord + Clone {}
+
+impl<'a, K, V> Iterator for Overlapping<'a, K, V>
+where
+    K: Ord + Clone,
+{
+    type Item = (&'a RangeInclusive<K>, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((k, v)) = self.btm_range_iter.next() {
+            if k.end_wrapper.range.start() <= self.query_range.end() {
+                Some((&k.end_wrapper.range, v))
+            } else {
+                // The rest of the items in the underlying iterator
+                // are past the query range. We can keep taking items
+                // from that iterator and this will remain true,
+                // so this is enough to make the iterator fused.
+                None
+            }
         } else {
             None
         }
@@ -1422,6 +1505,82 @@ mod tests {
         // Gaps iterator should be fused.
         assert_eq!(gaps.next(), None);
         assert_eq!(gaps.next(), None);
+    }
+
+    // Overlapping tests
+
+    #[test]
+    fn overlapping_with_empty_map() {
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        let range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆-------------◆ ◌
+        let query_range = 1..=8;
+        let mut overlapping = range_map.overlapping(&query_range);
+        // Should not yield any items.
+        assert_eq!(overlapping.next(), None);
+        // Gaps iterator should be fused.
+        assert_eq!(overlapping.next(), None);
+    }
+
+    #[test]
+    fn overlapping_partial_edges_complete_middle() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(0..=1, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ●-● ◌ ◌ ◌ ◌ ◌
+        range_map.insert(3..=4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●-● ◌ ◌
+        range_map.insert(6..=7, ());
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---------◆ ◌ ◌ ◌
+        let query_range = 1..=6;
+
+        let mut overlapping = range_map.overlapping(&query_range);
+
+        // Should yield partially overlapped range at start.
+        assert_eq!(overlapping.next(), Some((&(0..=1), &())));
+        // Should yield completely overlapped range in middle.
+        assert_eq!(overlapping.next(), Some((&(3..=4), &())));
+        // Should yield partially overlapped range at end.
+        assert_eq!(overlapping.next(), Some((&(6..=7), &())));
+        // Gaps iterator should be fused.
+        assert_eq!(overlapping.next(), None);
+        assert_eq!(overlapping.next(), None);
+    }
+
+    #[test]
+    fn overlapping_non_overlapping_edges_complete_middle() {
+        let mut range_map: RangeInclusiveMap<u32, ()> = RangeInclusiveMap::new();
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_map.insert(0..=1, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ●-● ◌ ◌ ◌ ◌ ◌
+        range_map.insert(3..=4, ());
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●-● ◌ ◌
+        range_map.insert(6..=7, ());
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◆-----◆ ◌ ◌ ◌ ◌
+        let query_range = 2..=5;
+
+        let mut overlapping = range_map.overlapping(&query_range);
+
+        // Should only yield the completely overlapped range in middle.
+        // (Not the ranges that are touched by not covered to either side.)
+        assert_eq!(overlapping.next(), Some((&(3..=4), &())));
+        // Gaps iterator should be fused.
+        assert_eq!(overlapping.next(), None);
+        assert_eq!(overlapping.next(), None);
     }
 
     ///

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -184,6 +184,16 @@ where
             inner: self.rm.gaps(outer_range),
         }
     }
+
+    /// Gets an iterator over all the stored ranges that are
+    /// either partially or completely overlapped by the given range.
+    ///
+    /// The iterator element type is `RangeInclusive<T>`.
+    pub fn overlapping<'a>(&'a self, range: &'a RangeInclusive<T>) -> Overlapping<T> {
+        Overlapping {
+            inner: self.rm.overlapping(range),
+        }
+    }
 }
 
 /// An iterator over the ranges of a `RangeInclusiveSet`.
@@ -370,6 +380,31 @@ where
     }
 }
 
+/// An iterator over all stored ranges partially or completely
+/// overlapped by a given range.
+///
+/// This `struct` is created by the [`overlapping`] method on [`RangeInclusiveSet`]. See its
+/// documentation for more.
+///
+/// [`overlapping`]: RangeInclusiveSet::overlapping
+pub struct Overlapping<'a, T> {
+    inner: crate::inclusive_map::Overlapping<'a, T, ()>,
+}
+
+// `Overlapping` is always fused. (See definition of `next` below.)
+impl<'a, T> core::iter::FusedIterator for Overlapping<'a, T> where T: Ord + Clone {}
+
+impl<'a, T> Iterator for Overlapping<'a, T>
+where
+    T: Ord + Clone,
+{
+    type Item = &'a RangeInclusive<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(k, _v)| k)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -431,6 +466,37 @@ mod tests {
         // Gaps iterator should be fused.
         assert_eq!(gaps.next(), None);
         assert_eq!(gaps.next(), None);
+    }
+
+    #[test]
+    fn overlapping_partial_edges_complete_middle() {
+        let mut range_set: RangeInclusiveSet<u32> = RangeInclusiveSet::new();
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ●-● ◌ ◌ ◌ ◌ ◌ ◌ ◌ ◌
+        range_set.insert(0..=1);
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ●-● ◌ ◌ ◌ ◌ ◌
+        range_set.insert(3..=4);
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◌ ◌ ◌ ◌ ◌ ●-● ◌ ◌
+        range_set.insert(6..=7);
+
+        // 0 1 2 3 4 5 6 7 8 9
+        // ◌ ◆---------◆ ◌ ◌ ◌
+        let query_range = 1..=6;
+
+        let mut overlapping = range_set.overlapping(&query_range);
+
+        // Should yield partially overlapped range at start.
+        assert_eq!(overlapping.next(), Some(&(0..=1)));
+        // Should yield completely overlapped range in middle.
+        assert_eq!(overlapping.next(), Some(&(3..=4)));
+        // Should yield partially overlapped range at end.
+        assert_eq!(overlapping.next(), Some(&(6..=7)));
+        // Gaps iterator should be fused.
+        assert_eq!(overlapping.next(), None);
+        assert_eq!(overlapping.next(), None);
     }
 
     ///

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -194,6 +194,12 @@ where
             inner: self.rm.overlapping(range),
         }
     }
+
+    /// Returns `true` if any range in the set completely or partially
+    /// overlaps the given range.
+    pub fn overlaps(&self, range: &RangeInclusive<T>) -> bool {
+        self.overlapping(range).next().is_some()
+    }
 }
 
 /// An iterator over the ranges of a `RangeInclusiveSet`.

--- a/src/map.rs
+++ b/src/map.rs
@@ -113,14 +113,12 @@ where
         self.btm
             .range((Bound::Unbounded, Bound::Included(key_as_start)))
             .next_back()
-            .filter(|(range_start_wrapper, _value)| {
+            .filter(|(start_wrapper, _value)| {
                 // Does the only candidate range contain
                 // the requested key?
-                range_start_wrapper.range_end_wrapper.range.contains(key)
+                start_wrapper.end_wrapper.range.contains(key)
             })
-            .map(|(range_start_wrapper, value)| {
-                (&range_start_wrapper.range_end_wrapper.range, value)
-            })
+            .map(|(start_wrapper, value)| (&start_wrapper.end_wrapper.range, value))
     }
 
     /// Returns `true` if any range in the map covers the specified key.
@@ -174,7 +172,7 @@ where
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.
         // See `range_wrapper.rs` for explanation of these hacks.
-        let mut new_range_start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
+        let mut new_start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
         let new_value = value;
 
         // Is there a stored range either overlapping the start of
@@ -187,31 +185,30 @@ where
             .btm
             .range::<RangeStartWrapper<K>, (Bound<&RangeStartWrapper<K>>, Bound<&RangeStartWrapper<K>>)>((
                 Bound::Unbounded,
-                Bound::Included(&new_range_start_wrapper),
+                Bound::Included(&new_start_wrapper),
             ))
             .rev()
             .take(2)
-            .filter(|(stored_range_start_wrapper, _stored_value)| {
+            .filter(|(stored_start_wrapper, _stored_value)| {
                 // Does the candidate range either overlap
                 // or immediately precede the range to insert?
                 // (Remember that it might actually cover the _whole_
                 // range to insert and then some.)
-                stored_range_start_wrapper
-                    .range_end_wrapper
+                stored_start_wrapper
+                    .end_wrapper
                     .range
-                    .touches(&new_range_start_wrapper.range_end_wrapper.range)
+                    .touches(&new_start_wrapper.end_wrapper.range)
             });
         if let Some(mut candidate) = candidates.next() {
             // Or the one before it if both cases described above exist.
             if let Some(another_candidate) = candidates.next() {
                 candidate = another_candidate;
             }
-            let (stored_range_start_wrapper, stored_value) =
-                (candidate.0.clone(), candidate.1.clone());
+            let (stored_start_wrapper, stored_value) = (candidate.0.clone(), candidate.1.clone());
             self.adjust_touching_ranges_for_insert(
-                stored_range_start_wrapper,
+                stored_start_wrapper,
                 stored_value,
-                &mut new_range_start_wrapper.range_end_wrapper.range,
+                &mut new_start_wrapper.end_wrapper.range,
                 &new_value,
             );
         }
@@ -229,13 +226,13 @@ where
         // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeStartWrapper<T>`
         // and use that to search here, to avoid constructing another `RangeStartWrapper`.
         let new_range_end_as_start = RangeStartWrapper::new(
-            new_range_start_wrapper.range_end_wrapper.range.end.clone()
-                ..new_range_start_wrapper.range_end_wrapper.range.end.clone(),
+            new_start_wrapper.end_wrapper.range.end.clone()
+                ..new_start_wrapper.end_wrapper.range.end.clone(),
         );
-        while let Some((stored_range_start_wrapper, stored_value)) = self
+        while let Some((stored_start_wrapper, stored_value)) = self
             .btm
             .range::<RangeStartWrapper<K>, (Bound<&RangeStartWrapper<K>>, Bound<&RangeStartWrapper<K>>)>((
-                Bound::Included(&new_range_start_wrapper),
+                Bound::Included(&new_start_wrapper),
                 Bound::Included(&new_range_end_as_start),
             ))
             .next()
@@ -244,8 +241,8 @@ where
             // and the stored range starts at the end of the range to insert,
             // then we don't want to keep looping forever trying to find more!
             #[allow(clippy::suspicious_operation_groupings)]
-            if stored_range_start_wrapper.range_end_wrapper.range.start
-                == new_range_start_wrapper.range_end_wrapper.range.end
+            if stored_start_wrapper.end_wrapper.range.start
+                == new_start_wrapper.end_wrapper.range.end
                 && *stored_value != new_value
             {
                 // We're beyond the last stored range that could be relevant.
@@ -256,19 +253,19 @@ where
                 break;
             }
 
-            let stored_range_start_wrapper = stored_range_start_wrapper.clone();
+            let stored_start_wrapper = stored_start_wrapper.clone();
             let stored_value = stored_value.clone();
 
             self.adjust_touching_ranges_for_insert(
-                stored_range_start_wrapper,
+                stored_start_wrapper,
                 stored_value,
-                &mut new_range_start_wrapper.range_end_wrapper.range,
+                &mut new_start_wrapper.end_wrapper.range,
                 &new_value,
             );
         }
 
         // Insert the (possibly expanded) new range, and we're done!
-        self.btm.insert(new_range_start_wrapper, new_value);
+        self.btm.insert(new_start_wrapper, new_value);
     }
 
     /// Removes a range from the map, if all or any of it was present.
@@ -286,32 +283,32 @@ where
         // they don't represent anything meaningful in this structure.
         assert!(range.start < range.end);
 
-        let range_start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
-        let range = &range_start_wrapper.range_end_wrapper.range;
+        let start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
+        let range = &start_wrapper.end_wrapper.range;
 
         // Is there a stored range overlapping the start of
         // the range to insert?
         //
         // If there is any such stored range, it will be the last
         // whose start is less than or equal to the start of the range to insert.
-        if let Some((stored_range_start_wrapper, stored_value)) = self
+        if let Some((stored_start_wrapper, stored_value)) = self
             .btm
-            .range::<RangeStartWrapper<K>, (Bound<&RangeStartWrapper<K>>, Bound<&RangeStartWrapper<K>>)>((Bound::Unbounded, Bound::Included(&range_start_wrapper)))
+            .range::<RangeStartWrapper<K>, (Bound<&RangeStartWrapper<K>>, Bound<&RangeStartWrapper<K>>)>((Bound::Unbounded, Bound::Included(&start_wrapper)))
             .next_back()
-            .filter(|(stored_range_start_wrapper, _stored_value)| {
+            .filter(|(stored_start_wrapper, _stored_value)| {
                 // Does the only candidate range overlap
                 // the range to insert?
-                stored_range_start_wrapper
-                    .range_end_wrapper
+                stored_start_wrapper
+                    .end_wrapper
                     .range
                     .overlaps(range)
             })
-            .map(|(stored_range_start_wrapper, stored_value)| {
-                (stored_range_start_wrapper.clone(), stored_value.clone())
+            .map(|(stored_start_wrapper, stored_value)| {
+                (stored_start_wrapper.clone(), stored_value.clone())
             })
         {
             self.adjust_overlapping_ranges_for_remove(
-                stored_range_start_wrapper,
+                stored_start_wrapper,
                 stored_value,
                 range,
             );
@@ -326,19 +323,19 @@ where
         // REVISIT: Possible micro-optimisation: `impl Borrow<T> for RangeStartWrapper<T>`
         // and use that to search here, to avoid constructing another `RangeStartWrapper`.
         let new_range_end_as_start = RangeStartWrapper::new(range.end.clone()..range.end.clone());
-        while let Some((stored_range_start_wrapper, stored_value)) = self
+        while let Some((stored_start_wrapper, stored_value)) = self
             .btm
             .range::<RangeStartWrapper<K>, (Bound<&RangeStartWrapper<K>>, Bound<&RangeStartWrapper<K>>)>((
-                Bound::Excluded(&range_start_wrapper),
+                Bound::Excluded(&start_wrapper),
                 Bound::Excluded(&new_range_end_as_start),
             ))
             .next()
-            .map(|(stored_range_start_wrapper, stored_value)| {
-                (stored_range_start_wrapper.clone(), stored_value.clone())
+            .map(|(stored_start_wrapper, stored_value)| {
+                (stored_start_wrapper.clone(), stored_value.clone())
             })
         {
             self.adjust_overlapping_ranges_for_remove(
-                stored_range_start_wrapper,
+                stored_start_wrapper,
                 stored_value,
                 range,
             );
@@ -347,7 +344,7 @@ where
 
     fn adjust_touching_ranges_for_insert(
         &mut self,
-        stored_range_start_wrapper: RangeStartWrapper<K>,
+        stored_start_wrapper: RangeStartWrapper<K>,
         stored_value: V,
         new_range: &mut Range<K>,
         new_value: &V,
@@ -361,40 +358,30 @@ where
             // This means that no matter how big or where the stored range is,
             // we will expand the new range's bounds to subsume it,
             // and then delete the stored range.
-            new_range.start = min(
-                &new_range.start,
-                &stored_range_start_wrapper.range_end_wrapper.range.start,
-            )
-            .clone();
-            new_range.end = max(
-                &new_range.end,
-                &stored_range_start_wrapper.range_end_wrapper.range.end,
-            )
-            .clone();
-            self.btm.remove(&stored_range_start_wrapper);
+            new_range.start = min(&new_range.start, &stored_start_wrapper.start).clone();
+            new_range.end = max(&new_range.end, &stored_start_wrapper.end).clone();
+            self.btm.remove(&stored_start_wrapper);
         } else {
             // The ranges have different values.
-            if new_range.overlaps(&stored_range_start_wrapper.range_end_wrapper.range) {
+            if new_range.overlaps(&stored_start_wrapper.range) {
                 // The ranges overlap. This is a little bit more complicated.
                 // Delete the stored range, and then add back between
                 // 0 and 2 subranges at the ends of the range to insert.
-                self.btm.remove(&stored_range_start_wrapper);
-                if stored_range_start_wrapper.range_end_wrapper.range.start < new_range.start {
+                self.btm.remove(&stored_start_wrapper);
+                if stored_start_wrapper.start < new_range.start {
                     // Insert the piece left of the range to insert.
                     self.btm.insert(
                         RangeStartWrapper::new(
-                            stored_range_start_wrapper.range_end_wrapper.range.start
-                                ..new_range.start.clone(),
+                            stored_start_wrapper.end_wrapper.range.start..new_range.start.clone(),
                         ),
                         stored_value.clone(),
                     );
                 }
-                if stored_range_start_wrapper.range_end_wrapper.range.end > new_range.end {
+                if stored_start_wrapper.end_wrapper.range.end > new_range.end {
                     // Insert the piece right of the range to insert.
                     self.btm.insert(
                         RangeStartWrapper::new(
-                            new_range.end.clone()
-                                ..stored_range_start_wrapper.range_end_wrapper.range.end,
+                            new_range.end.clone()..stored_start_wrapper.end_wrapper.range.end,
                         ),
                         stored_value,
                     );
@@ -408,15 +395,15 @@ where
 
     fn adjust_overlapping_ranges_for_remove(
         &mut self,
-        stored_range_start_wrapper: RangeStartWrapper<K>,
+        stored: RangeStartWrapper<K>,
         stored_value: V,
         range_to_remove: &Range<K>,
     ) {
         // Delete the stored range, and then add back between
         // 0 and 2 subranges at the ends of the range to insert.
-        self.btm.remove(&stored_range_start_wrapper);
-        let stored_range = stored_range_start_wrapper.range_end_wrapper;
-        if stored_range.range.start < range_to_remove.start {
+        self.btm.remove(&stored);
+        let stored_range = stored.end_wrapper;
+        if stored_range.start < range_to_remove.start {
             // Insert the piece left of the range to insert.
             self.btm.insert(
                 RangeStartWrapper::new(stored_range.range.start..range_to_remove.start.clone()),
@@ -493,7 +480,7 @@ where
     fn next(&mut self) -> Option<(&'a Range<K>, &'a V)> {
         self.inner
             .next()
-            .map(|(by_start, v)| (&by_start.range_end_wrapper.range, v))
+            .map(|(by_start, v)| (&by_start.end_wrapper.range, v))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -528,7 +515,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
     fn next(&mut self) -> Option<(Range<K>, V)> {
         self.inner
             .next()
-            .map(|(by_start, v)| (by_start.range_end_wrapper.range, v))
+            .map(|(by_start, v)| (by_start.end_wrapper.range, v))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
@@ -668,7 +655,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         for item in &mut self.keys {
-            let range = &item.range_end_wrapper.range;
+            let range = &item.range;
             if range.end <= *self.candidate_start {
                 // We're already completely past it; ignore it.
             } else if range.start <= *self.candidate_start {
@@ -723,8 +710,8 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some((k, v)) = self.btm_range_iter.next() {
-            if k.range_end_wrapper.range.start < self.query_range.end {
-                Some((&k.range_end_wrapper.range, v))
+            if k.start < self.query_range.end {
+                Some((&k.range, v))
             } else {
                 // The rest of the items in the underlying iterator
                 // are past the query range. We can keep taking items

--- a/src/map.rs
+++ b/src/map.rs
@@ -456,6 +456,12 @@ where
             btm_range_iter,
         }
     }
+
+    /// Returns `true` if any range in the map completely or partially
+    /// overlaps the given range.
+    pub fn overlaps(&self, range: &Range<K>) -> bool {
+        self.overlapping(range).next().is_some()
+    }
 }
 
 /// An iterator over the entries of a `RangeMap`, ordered by key range.

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -26,7 +26,7 @@
 // inner range!
 
 use core::cmp::Ordering;
-use core::ops::{Range, RangeInclusive};
+use core::ops::{Deref, Range, RangeInclusive};
 
 //
 // Range start wrapper
@@ -34,13 +34,13 @@ use core::ops::{Range, RangeInclusive};
 
 #[derive(Debug, Clone)]
 pub struct RangeStartWrapper<T> {
-    pub range_end_wrapper: RangeEndWrapper<T>,
+    pub end_wrapper: RangeEndWrapper<T>,
 }
 
 impl<T> RangeStartWrapper<T> {
     pub fn new(range: Range<T>) -> RangeStartWrapper<T> {
         RangeStartWrapper {
-            range_end_wrapper: RangeEndWrapper::new(range),
+            end_wrapper: RangeEndWrapper::new(range),
         }
     }
 }
@@ -50,7 +50,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeStartWrapper<T>) -> bool {
-        self.range_end_wrapper.range.start == other.range_end_wrapper.range.start
+        self.start == other.start
     }
 }
 
@@ -61,10 +61,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &RangeStartWrapper<T>) -> Ordering {
-        self.range_end_wrapper
-            .range
-            .start
-            .cmp(&other.range_end_wrapper.range.start)
+        self.start.cmp(&other.start)
     }
 }
 
@@ -73,16 +70,23 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeStartWrapper<T>) -> Option<Ordering> {
-        self.range_end_wrapper
-            .range
-            .start
-            .partial_cmp(&other.range_end_wrapper.range.start)
+        self.start.partial_cmp(&other.start)
     }
 }
 
 impl<T> core::borrow::Borrow<RangeEndWrapper<T>> for RangeStartWrapper<T> {
     fn borrow(&self) -> &RangeEndWrapper<T> {
-        &self.range_end_wrapper
+        &self.end_wrapper
+    }
+}
+
+// Avoid the need to tediously plumb through the layers of wrapper structs
+// when you're just trying to access members of the inner range itself.
+impl<T> Deref for RangeStartWrapper<T> {
+    type Target = RangeEndWrapper<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.end_wrapper
     }
 }
 
@@ -106,7 +110,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeEndWrapper<T>) -> bool {
-        self.range.end == other.range.end
+        self.end == other.end
     }
 }
 
@@ -117,7 +121,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &RangeEndWrapper<T>) -> Ordering {
-        self.range.end.cmp(&other.range.end)
+        self.end.cmp(&other.end)
     }
 }
 
@@ -126,13 +130,17 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeEndWrapper<T>) -> Option<Ordering> {
-        self.range.end.partial_cmp(&other.range.end)
+        self.end.partial_cmp(&other.end)
     }
 }
 
-impl<T> core::borrow::Borrow<RangeInclusiveEndWrapper<T>> for RangeInclusiveStartWrapper<T> {
-    fn borrow(&self) -> &RangeInclusiveEndWrapper<T> {
-        &self.end_wrapper
+// Avoid the need to tediously plumb through the layers of wrapper structs
+// when you're just trying to access members of the inner range itself.
+impl<T> Deref for RangeEndWrapper<T> {
+    type Target = Range<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.range
     }
 }
 
@@ -158,7 +166,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeInclusiveStartWrapper<T>) -> bool {
-        self.end_wrapper.range.start() == other.end_wrapper.range.start()
+        self.start() == other.start()
     }
 }
 
@@ -167,10 +175,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Ordering {
-        self.end_wrapper
-            .range
-            .start()
-            .cmp(other.end_wrapper.range.start())
+        self.start().cmp(other.start())
     }
 }
 
@@ -179,10 +184,23 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Option<Ordering> {
-        self.end_wrapper
-            .range
-            .start()
-            .partial_cmp(other.end_wrapper.range.start())
+        self.start().partial_cmp(other.start())
+    }
+}
+
+impl<T> core::borrow::Borrow<RangeInclusiveEndWrapper<T>> for RangeInclusiveStartWrapper<T> {
+    fn borrow(&self) -> &RangeInclusiveEndWrapper<T> {
+        &self.end_wrapper
+    }
+}
+
+// Avoid the need to tediously plumb through the layers of wrapper structs
+// when you're just trying to access members of the inner range itself.
+impl<T> Deref for RangeInclusiveStartWrapper<T> {
+    type Target = RangeInclusiveEndWrapper<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.end_wrapper
     }
 }
 
@@ -206,7 +224,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeInclusiveEndWrapper<T>) -> bool {
-        self.range.end() == other.range.end()
+        self.end() == other.end()
     }
 }
 
@@ -215,7 +233,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &RangeInclusiveEndWrapper<T>) -> Ordering {
-        self.range.end().cmp(other.range.end())
+        self.end().cmp(other.end())
     }
 }
 
@@ -224,6 +242,16 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeInclusiveEndWrapper<T>) -> Option<Ordering> {
-        self.range.end().partial_cmp(other.range.end())
+        self.end().partial_cmp(other.end())
+    }
+}
+
+// Avoid the need to tediously plumb through the layers of wrapper structs
+// when you're just trying to access members of the inner range itself.
+impl<T> Deref for RangeInclusiveEndWrapper<T> {
+    type Target = RangeInclusive<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.range
     }
 }

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -130,18 +130,26 @@ where
     }
 }
 
+impl<T> core::borrow::Borrow<RangeInclusiveEndWrapper<T>> for RangeInclusiveStartWrapper<T> {
+    fn borrow(&self) -> &RangeInclusiveEndWrapper<T> {
+        &self.end_wrapper
+    }
+}
+
 //
 // RangeInclusive start wrapper
 //
 
 #[derive(Eq, Debug, Clone)]
 pub struct RangeInclusiveStartWrapper<T> {
-    pub range: RangeInclusive<T>,
+    pub end_wrapper: RangeInclusiveEndWrapper<T>,
 }
 
 impl<T> RangeInclusiveStartWrapper<T> {
     pub fn new(range: RangeInclusive<T>) -> RangeInclusiveStartWrapper<T> {
-        RangeInclusiveStartWrapper { range }
+        RangeInclusiveStartWrapper {
+            end_wrapper: RangeInclusiveEndWrapper::new(range),
+        }
     }
 }
 
@@ -150,7 +158,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &RangeInclusiveStartWrapper<T>) -> bool {
-        self.range.start() == other.range.start()
+        self.end_wrapper.range.start() == other.end_wrapper.range.start()
     }
 }
 
@@ -159,7 +167,10 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Ordering {
-        self.range.start().cmp(other.range.start())
+        self.end_wrapper
+            .range
+            .start()
+            .cmp(other.end_wrapper.range.start())
     }
 }
 
@@ -168,6 +179,51 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &RangeInclusiveStartWrapper<T>) -> Option<Ordering> {
-        self.range.start().partial_cmp(other.range.start())
+        self.end_wrapper
+            .range
+            .start()
+            .partial_cmp(other.end_wrapper.range.start())
+    }
+}
+
+//
+// RangeInclusive end wrapper
+//
+
+#[derive(Eq, Debug, Clone)]
+pub struct RangeInclusiveEndWrapper<T> {
+    pub range: RangeInclusive<T>,
+}
+
+impl<T> RangeInclusiveEndWrapper<T> {
+    pub fn new(range: RangeInclusive<T>) -> RangeInclusiveEndWrapper<T> {
+        RangeInclusiveEndWrapper { range }
+    }
+}
+
+impl<T> PartialEq for RangeInclusiveEndWrapper<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &RangeInclusiveEndWrapper<T>) -> bool {
+        self.range.end() == other.range.end()
+    }
+}
+
+impl<T> Ord for RangeInclusiveEndWrapper<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &RangeInclusiveEndWrapper<T>) -> Ordering {
+        self.range.end().cmp(other.range.end())
+    }
+}
+
+impl<T> PartialOrd for RangeInclusiveEndWrapper<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &RangeInclusiveEndWrapper<T>) -> Option<Ordering> {
+        self.range.end().partial_cmp(other.range.end())
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -168,6 +168,12 @@ where
             inner: self.rm.overlapping(range),
         }
     }
+
+    /// Returns `true` if any range in the set completely or partially
+    /// overlaps the given range.
+    pub fn overlaps(&self, range: &Range<T>) -> bool {
+        self.overlapping(range).next().is_some()
+    }
 }
 
 /// An iterator over the ranges of a `RangeSet`.


### PR DESCRIPTION
- Misc tidy-ups, a bit more testing.
- Add `overlaps` convenience method to all collection types, which returns whether any stored range completely or partially overlaps a given range.
 