### PR TITLE
Make overlapping/overlaps accept ranges by-value instead of by-reference

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -527,7 +527,7 @@ where
 
     /// Gets an iterator over all the stored ranges that are
     /// either partially or completely overlapped by the given range.
-    pub fn overlapping<'a>(&'a self, range: &'a RangeInclusive<K>) -> Overlapping<K, V> {
+    pub fn overlapping<'a>(&'a self, range: RangeInclusive<K>) -> Overlapping<K, V> {
         // Find the first matching stored range by its _end_,
         // using sneaky layering and `Borrow` implementation. (See `range_wrappers` module.)
         let start_sliver =
@@ -545,7 +545,7 @@ where
 
     /// Returns `true` if any range in the map completely or partially
     /// overlaps the given range.
-    pub fn overlaps(&self, range: &RangeInclusive<K>) -> bool {
+    pub fn overlaps(&self, range: RangeInclusive<K>) -> bool {
         self.overlapping(range).next().is_some()
     }
 }
@@ -812,7 +812,7 @@ where
 ///
 /// [`overlapping`]: RangeInclusiveMap::overlapping
 pub struct Overlapping<'a, K, V> {
-    query_range: &'a RangeInclusive<K>,
+    query_range: RangeInclusive<K>,
     btm_range_iter: alloc::collections::btree_map::Range<'a, RangeInclusiveStartWrapper<K>, V>,
 }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -189,7 +189,7 @@ where
     /// either partially or completely overlapped by the given range.
     ///
     /// The iterator element type is `RangeInclusive<T>`.
-    pub fn overlapping<'a>(&'a self, range: &'a RangeInclusive<T>) -> Overlapping<T> {
+    pub fn overlapping<'a>(&'a self, range: RangeInclusive<T>) -> Overlapping<T> {
         Overlapping {
             inner: self.rm.overlapping(range),
         }
@@ -197,7 +197,7 @@ where
 
     /// Returns `true` if any range in the set completely or partially
     /// overlaps the given range.
-    pub fn overlaps(&self, range: &RangeInclusive<T>) -> bool {
+    pub fn overlaps(&self, range: RangeInclusive<T>) -> bool {
         self.overlapping(range).next().is_some()
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -170,7 +170,7 @@ where
 
     /// Gets an iterator over all the stored ranges that are
     /// either partially or completely overlapped by the given range.
-    pub fn overlapping<'a>(&'a self, range: &'a Range<K>) -> Overlapping<K, V> {
+    pub fn overlapping<'a>(&'a self, range: Range<K>) -> Overlapping<K, V> {
         // Find the first matching stored range by its _end_,
         // using sneaky layering and `Borrow` implementation. (See `range_wrappers` module.)
         let start_sliver = RangeEndWrapper::new(range.start.clone()..range.start.clone());
@@ -188,7 +188,7 @@ where
 
     /// Returns `true` if any range in the map completely or partially
     /// overlaps the given range.
-    pub fn overlaps(&self, range: &Range<K>) -> bool {
+    pub fn overlaps(&self, range: Range<K>) -> bool {
         self.overlapping(range).next().is_some()
     }
 }
@@ -700,7 +700,7 @@ where
 ///
 /// [`overlapping`]: RangeMap::overlapping
 pub struct Overlapping<'a, K, V> {
-    query_range: &'a Range<K>,
+    query_range: Range<K>,
     btm_range_iter: alloc::collections::btree_map::Range<'a, RangeStartWrapper<K>, V>,
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -163,7 +163,7 @@ where
     /// either partially or completely overlapped by the given range.
     ///
     /// The iterator element type is `&Range<T>`.
-    pub fn overlapping<'a>(&'a self, range: &'a Range<T>) -> Overlapping<T> {
+    pub fn overlapping<'a>(&'a self, range: Range<T>) -> Overlapping<T> {
         Overlapping {
             inner: self.rm.overlapping(range),
         }
@@ -171,7 +171,7 @@ where
 
     /// Returns `true` if any range in the set completely or partially
     /// overlaps the given range.
-    pub fn overlaps(&self, range: &Range<T>) -> bool {
+    pub fn overlaps(&self, range: Range<T>) -> bool {
         self.overlapping(range).next().is_some()
     }
 }


### PR DESCRIPTION
Breaking change, but I find this kind of change necessary to interface properly with this API.

Main reasons:

1. These ranges will primarily be of integers, who are `Copy` anyway.
2. Without taking ownership of the range, generating one on-the-fly is basically impossible.

Essentially, if you have an iterator method which uses `overlapping` internally, it will *only* work properly if you pass in a reference to a range directly from the top level; anything else will be insufficient, unless you want to use `Box::leak`, which is quite wasteful.