### PR TITLE
Derive Clone/Debug for iterators

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -558,6 +558,7 @@ where
 /// documentation for more.
 ///
 /// [`iter`]: RangeInclusiveMap::iter
+#[derive(Clone, Debug)]
 pub struct Iter<'a, K, V> {
     inner: alloc::collections::btree_map::Iter<'a, RangeInclusiveStartWrapper<K>, V>,
 }
@@ -586,6 +587,7 @@ where
 /// (provided by the `IntoIterator` trait). See its documentation for more.
 ///
 /// [`into_iter`]: IntoIterator::into_iter
+#[derive(Debug)]
 pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeInclusiveStartWrapper<K>, V>,
 }
@@ -811,6 +813,7 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeInclusiveMap::overlapping
+#[derive(Clone, Debug)]
 pub struct Overlapping<'a, K, V> {
     query_range: &'a RangeInclusive<K>,
     btm_range_iter: alloc::collections::btree_map::Range<'a, RangeInclusiveStartWrapper<K>, V>,

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -208,6 +208,7 @@ where
 /// documentation for more.
 ///
 /// [`iter`]: RangeInclusiveSet::iter
+#[derive(Clone, Debug)]
 pub struct Iter<'a, T> {
     inner: super::inclusive_map::Iter<'a, T, ()>,
 }
@@ -230,6 +231,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 /// (provided by the `IntoIterator` trait). See its documentation for more.
 ///
 /// [`into_iter`]: IntoIterator::into_iter
+#[derive(Debug)]
 pub struct IntoIter<T> {
     inner: super::inclusive_map::IntoIter<T, ()>,
 }
@@ -393,6 +395,7 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeInclusiveSet::overlapping
+#[derive(Clone, Debug)]
 pub struct Overlapping<'a, T> {
     inner: crate::inclusive_map::Overlapping<'a, T, ()>,
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -475,6 +475,7 @@ where
 /// documentation for more.
 ///
 /// [`iter`]: RangeMap::iter
+#[derive(Clone, Debug)]
 pub struct Iter<'a, K, V> {
     inner: alloc::collections::btree_map::Iter<'a, RangeStartWrapper<K>, V>,
 }
@@ -505,6 +506,7 @@ where
 /// (provided by the `IntoIterator` trait). See its documentation for more.
 ///
 /// [`into_iter`]: IntoIterator::into_iter
+#[derive(Debug)]
 pub struct IntoIter<K, V> {
     inner: alloc::collections::btree_map::IntoIter<RangeStartWrapper<K>, V>,
 }
@@ -699,6 +701,7 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeMap::overlapping
+#[derive(Clone, Debug)]
 pub struct Overlapping<'a, K, V> {
     query_range: &'a Range<K>,
     btm_range_iter: alloc::collections::btree_map::Range<'a, RangeStartWrapper<K>, V>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -182,6 +182,7 @@ where
 /// documentation for more.
 ///
 /// [`iter`]: RangeSet::iter
+#[derive(Clone, Debug)]
 pub struct Iter<'a, T> {
     inner: super::map::Iter<'a, T, ()>,
 }
@@ -204,6 +205,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 /// (provided by the `IntoIterator` trait). See its documentation for more.
 ///
 /// [`into_iter`]: IntoIterator::into_iter
+#[derive(Debug)]
 pub struct IntoIter<T> {
     inner: super::map::IntoIter<T, ()>,
 }
@@ -361,6 +363,7 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeSet::overlapping
+#[derive(Clone, Debug)]
 pub struct Overlapping<'a, T> {
     inner: crate::map::Overlapping<'a, T, ()>,
 }


### PR DESCRIPTION
Affects `Overlapping`, `Iter`, and `IntoIter` iterators, although since the `BTreeMap` version of `IntoIter` doesn't implement `Clone`, this just derives `Debug` for that one.

Technically, they could have better-crafted `Debug` impls, but at least having one for now is better than none, and it's not the worst.