### PR TITLE
Fix `PartialEq`, `PartialOrd`, and `Ord` implementations for `RangeMap` (and `RangeSet`)

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,6 @@ use super::range_wrapper::RangeStartWrapper;
 use crate::range_wrapper::RangeEndWrapper;
 use crate::std_ext::*;
 use alloc::collections::BTreeMap;
-use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::{Bound, Range};
@@ -40,29 +39,14 @@ where
     V: PartialEq,
 {
     fn eq(&self, other: &RangeMap<K, V>) -> bool {
-        self.btm == other.btm
-    }
-}
+        if self.btm.len() != other.btm.len() {
+            return false;
+        }
 
-impl<K, V> PartialOrd for RangeMap<K, V>
-where
-    K: PartialOrd,
-    V: PartialOrd,
-{
-    #[inline]
-    fn partial_cmp(&self, other: &RangeMap<K, V>) -> Option<Ordering> {
-        self.btm.partial_cmp(&other.btm)
-    }
-}
-
-impl<K, V> Ord for RangeMap<K, V>
-where
-    K: Ord,
-    V: Ord,
-{
-    #[inline]
-    fn cmp(&self, other: &RangeMap<K, V>) -> Ordering {
-        self.btm.cmp(&other.btm)
+        self.btm
+            .iter()
+            .zip(other.btm.iter())
+            .all(|((k1, v1), (k2, v2))| k1.start == k2.start && k1.end == k2.end && v1 == v2)
     }
 }
 
@@ -1468,6 +1452,18 @@ mod tests {
 
         // Equality
         assert_eq!(cloned, consumed);
+    }
+
+    // Equality test
+    #[test]
+    fn equality() {
+        let mut a: RangeMap<u32, bool> = RangeMap::new();
+        a.insert(1..3, false);
+
+        let mut b: RangeMap<u32, bool> = RangeMap::new();
+        b.insert(1..4, false);
+
+        assert_ne!(a, b);
     }
 
     // impl Serialize

--- a/src/map.rs
+++ b/src/map.rs
@@ -1486,7 +1486,15 @@ mod tests {
         let mut b: RangeMap<u32, bool> = RangeMap::new();
         b.insert(1..4, false);
 
+        let mut c: RangeMap<u32, bool> = RangeMap::new();
+        c.insert(1..3, false);
+
         assert_ne!(a, b);
+        assert_ne!(b, a);
+
+        assert_eq!(a, c);
+        assert_eq!(c, a);
+        assert_eq!(a, a);
     }
 
     // Ord
@@ -1497,6 +1505,8 @@ mod tests {
 
         let mut b: RangeMap<u32, bool> = RangeMap::new();
         b.insert(1..4, false);
+
+        assert_eq!(a.partial_cmp(&a), Some(Ordering::Equal));
 
         assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
         assert_eq!(b.partial_cmp(&a), Some(Ordering::Greater));
@@ -1509,6 +1519,8 @@ mod tests {
 
         let mut b: RangeMap<u32, bool> = RangeMap::new();
         b.insert(1..4, false);
+
+        assert_eq!(a.cmp(&a), Ordering::Equal);
 
         assert_eq!(a.cmp(&b), Ordering::Less);
         assert_eq!(b.cmp(&a), Ordering::Greater);

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,3 +1,4 @@
+use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::Range;
@@ -43,6 +44,26 @@ where
 }
 
 impl<T> Eq for RangeSet<T> where T: Eq {}
+
+impl<T> PartialOrd for RangeSet<T>
+where
+    T: PartialOrd,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RangeSet<T>) -> Option<Ordering> {
+        self.rm.partial_cmp(&other.rm)
+    }
+}
+
+impl<T> Ord for RangeSet<T>
+where
+    T: Ord,
+{
+    #[inline]
+    fn cmp(&self, other: &RangeSet<T>) -> Ordering {
+        self.rm.cmp(&other.rm)
+    }
+}
 
 impl<T> RangeSet<T>
 where

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,3 @@
-use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::Range;
@@ -44,26 +43,6 @@ where
 }
 
 impl<T> Eq for RangeSet<T> where T: Eq {}
-
-impl<T> PartialOrd for RangeSet<T>
-where
-    T: PartialOrd,
-{
-    #[inline]
-    fn partial_cmp(&self, other: &RangeSet<T>) -> Option<Ordering> {
-        self.rm.partial_cmp(&other.rm)
-    }
-}
-
-impl<T> Ord for RangeSet<T>
-where
-    T: Ord,
-{
-    #[inline]
-    fn cmp(&self, other: &RangeSet<T>) -> Ordering {
-        self.rm.cmp(&other.rm)
-    }
-}
 
 impl<T> RangeSet<T>
 where


### PR DESCRIPTION
Since `RangeStartWrapper` only compares the `start` of its range, two `RangeMap`s with a range with same `start` but different `end` was considered equal.

The fix here directly compares the actual both ends of the ranges.

I have also removed the `PartialOrd` and `Ord` implementations for now, but they can be reimplemented in a similar way. Let me know!