### PR TITLE
Allow the `overlapping()` function to take ranges by value

### DIFF
--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,3 +1,4 @@
+use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
@@ -189,7 +190,7 @@ where
     /// either partially or completely overlapped by the given range.
     ///
     /// The iterator element type is `RangeInclusive<T>`.
-    pub fn overlapping<'a>(&'a self, range: &'a RangeInclusive<T>) -> Overlapping<T> {
+    pub fn overlapping<R: Borrow<RangeInclusive<T>>>(&self, range: R) -> Overlapping<T, R> {
         Overlapping {
             inner: self.rm.overlapping(range),
         }
@@ -393,14 +394,17 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeInclusiveSet::overlapping
-pub struct Overlapping<'a, T> {
-    inner: crate::inclusive_map::Overlapping<'a, T, ()>,
+pub struct Overlapping<'a, T, R: Borrow<RangeInclusive<T>> = &'a RangeInclusive<T>> {
+    inner: crate::inclusive_map::Overlapping<'a, T, (), R>,
 }
 
 // `Overlapping` is always fused. (See definition of `next` below.)
-impl<'a, T> core::iter::FusedIterator for Overlapping<'a, T> where T: Ord + Clone {}
+impl<'a, T, R: Borrow<RangeInclusive<T>>> core::iter::FusedIterator for Overlapping<'a, T, R> where
+    T: Ord + Clone
+{
+}
 
-impl<'a, T> Iterator for Overlapping<'a, T>
+impl<'a, T, R: Borrow<RangeInclusive<T>>> Iterator for Overlapping<'a, T, R>
 where
     T: Ord + Clone,
 {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,3 +1,4 @@
+use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
@@ -163,7 +164,7 @@ where
     /// either partially or completely overlapped by the given range.
     ///
     /// The iterator element type is `&Range<T>`.
-    pub fn overlapping<'a>(&'a self, range: &'a Range<T>) -> Overlapping<T> {
+    pub fn overlapping<R: Borrow<Range<T>>>(&self, range: R) -> Overlapping<T, R> {
         Overlapping {
             inner: self.rm.overlapping(range),
         }
@@ -361,14 +362,17 @@ where
 /// documentation for more.
 ///
 /// [`overlapping`]: RangeSet::overlapping
-pub struct Overlapping<'a, T> {
-    inner: crate::map::Overlapping<'a, T, ()>,
+pub struct Overlapping<'a, T, R: Borrow<Range<T>> = &'a Range<T>> {
+    inner: crate::map::Overlapping<'a, T, (), R>,
 }
 
 // `Overlapping` is always fused. (See definition of `next` below.)
-impl<'a, T> core::iter::FusedIterator for Overlapping<'a, T> where T: Ord + Clone {}
+impl<'a, T, R: Borrow<Range<T>>> core::iter::FusedIterator for Overlapping<'a, T, R> where
+    T: Ord + Clone
+{
+}
 
-impl<'a, T> Iterator for Overlapping<'a, T>
+impl<'a, T, R: Borrow<Range<T>>> Iterator for Overlapping<'a, T, R>
 where
     T: Ord + Clone,
 {


### PR DESCRIPTION
Instead of forcing the user of the `overlapping()` API to pass a range by reference, which causes the resulting iterator to have a lifetime which depends on this reference, the `Borrow` trait is used to give the user a choice to use either a reference or pass the range by value. The lifetime of the iterator accordingly depends on which of the two is chosen.

This pull request achieves a similar end as #70, however it does not break the existing API and allows for greater flexibility (giving the user of the API the choice of either passing the range as reference or passing a range by value.