### PR TITLE
Replaces manual trait implementations with derives

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -33,22 +33,12 @@ use serde::{
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`](crate::StepLite) is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone)]
+#[derive(Clone, Hash, Default)]
 pub struct RangeInclusiveMap<K, V, StepFnsT = K> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeInclusiveStartWrapper<K>, V>,
     _phantom: PhantomData<StepFnsT>,
-}
-
-impl<K, V> Default for RangeInclusiveMap<K, V, K>
-where
-    K: Ord + Clone + StepLite,
-    V: Eq + Clone,
-{
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl<K, V, StepFnsT> PartialEq for RangeInclusiveMap<K, V, StepFnsT>

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -15,7 +15,7 @@ use serde::{
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
 
-#[derive(Clone)]
+#[derive(Clone, Hash, Default)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
@@ -26,42 +26,33 @@ pub struct RangeInclusiveSet<T, StepFnsT = T> {
     rm: RangeInclusiveMap<T, (), StepFnsT>,
 }
 
-impl<T> Default for RangeInclusiveSet<T, T>
-where
-    T: Ord + Clone + StepLite,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T> PartialEq for RangeInclusiveSet<T, T>
+impl<T, StepFnsT> PartialEq for RangeInclusiveSet<T, StepFnsT>
 where
     T: PartialEq,
 {
-    fn eq(&self, other: &RangeInclusiveSet<T, T>) -> bool {
+    fn eq(&self, other: &Self) -> bool {
         self.rm == other.rm
     }
 }
 
-impl<T> Eq for RangeInclusiveSet<T, T> where T: Eq {}
+impl<T, StepFnsT> Eq for RangeInclusiveSet<T, StepFnsT> where T: Eq {}
 
-impl<T> PartialOrd for RangeInclusiveSet<T, T>
+impl<T, StepFnsT> PartialOrd for RangeInclusiveSet<T, StepFnsT>
 where
     T: PartialOrd,
 {
     #[inline]
-    fn partial_cmp(&self, other: &RangeInclusiveSet<T, T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.rm.partial_cmp(&other.rm)
     }
 }
 
-impl<T> Ord for RangeInclusiveSet<T, T>
+impl<T, StepFnsT> Ord for RangeInclusiveSet<T, StepFnsT>
 where
     T: Ord,
 {
     #[inline]
-    fn cmp(&self, other: &RangeInclusiveSet<T, T>) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.rm.cmp(&other.rm)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -22,17 +22,11 @@ use serde::{
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone)]
+#[derive(Clone, Hash, Default, Eq)]
 pub struct RangeMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeStartWrapper<K>, V>,
-}
-
-impl<K, V> Default for RangeMap<K, V> {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl<K, V> PartialEq for RangeMap<K, V>
@@ -65,13 +59,6 @@ where
     fn cmp(&self, other: &RangeMap<K, V>) -> Ordering {
         self.expanded_iter().cmp(other.expanded_iter())
     }
-}
-
-impl<K, V> Eq for RangeMap<K, V>
-where
-    K: Eq,
-    V: Eq,
-{
 }
 
 impl<K, V> RangeMap<K, V> {

--- a/src/range_wrapper.rs
+++ b/src/range_wrapper.rs
@@ -32,7 +32,7 @@ use core::ops::{Deref, Range, RangeInclusive};
 // Range start wrapper
 //
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct RangeStartWrapper<T> {
     pub end_wrapper: RangeEndWrapper<T>,
 }
@@ -94,7 +94,7 @@ impl<T> Deref for RangeStartWrapper<T> {
 // Range end wrapper
 //
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct RangeEndWrapper<T> {
     pub range: Range<T>,
 }
@@ -148,7 +148,7 @@ impl<T> Deref for RangeEndWrapper<T> {
 // RangeInclusive start wrapper
 //
 
-#[derive(Eq, Debug, Clone)]
+#[derive(Eq, Debug, Clone, Hash)]
 pub struct RangeInclusiveStartWrapper<T> {
     pub end_wrapper: RangeInclusiveEndWrapper<T>,
 }
@@ -208,7 +208,7 @@ impl<T> Deref for RangeInclusiveStartWrapper<T> {
 // RangeInclusive end wrapper
 //
 
-#[derive(Eq, Debug, Clone)]
+#[derive(Eq, Debug, Clone, Hash)]
 pub struct RangeInclusiveEndWrapper<T> {
     pub range: RangeInclusive<T>,
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,4 @@
 use core::borrow::Borrow;
-use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
 use core::ops::Range;
@@ -15,7 +14,7 @@ use serde::{
 
 use crate::RangeMap;
 
-#[derive(Clone)]
+#[derive(Clone, Hash, Default, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
@@ -24,46 +23,6 @@ use crate::RangeMap;
 /// [`RangeMap`]: struct.RangeMap.html
 pub struct RangeSet<T> {
     rm: RangeMap<T, ()>,
-}
-
-impl<T> Default for RangeSet<T>
-where
-    T: Ord + Clone,
-{
-    fn default() -> Self {
-        RangeSet::new()
-    }
-}
-
-impl<T> PartialEq for RangeSet<T>
-where
-    T: PartialEq,
-{
-    fn eq(&self, other: &RangeSet<T>) -> bool {
-        self.rm == other.rm
-    }
-}
-
-impl<T> Eq for RangeSet<T> where T: Eq {}
-
-impl<T> PartialOrd for RangeSet<T>
-where
-    T: PartialOrd,
-{
-    #[inline]
-    fn partial_cmp(&self, other: &RangeSet<T>) -> Option<Ordering> {
-        self.rm.partial_cmp(&other.rm)
-    }
-}
-
-impl<T> Ord for RangeSet<T>
-where
-    T: Ord,
-{
-    #[inline]
-    fn cmp(&self, other: &RangeSet<T>) -> Ordering {
-        self.rm.cmp(&other.rm)
-    }
 }
 
 impl<T> RangeSet<T>


### PR DESCRIPTION
In a few places, I spotted trait implementations which are able to be replaced with automatically derived versions. I also fixed the implementations for RangeInclusiveSet to be generic over the Step functions type.

These changes pass the tests, and should not introduce any major changes, but feel free to verify.