### PR TITLE
Don't panic on empty ranges.

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -214,14 +214,10 @@ where
     pub fn insert(&mut self, range: RangeInclusive<K>, value: V) {
         use core::ops::Bound;
 
-        // Backwards ranges don't make sense.
-        // `RangeInclusive` doesn't enforce this,
-        // and we don't want weird explosions further down
-        // if someone gives us such a range.
-        assert!(
-            range.start() <= range.end(),
-            "Range start can not be after range end"
-        );
+        // A range where start > end is empty..
+        if range.start() > range.end() {
+            return;
+        }
 
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.

--- a/src/map.rs
+++ b/src/map.rs
@@ -221,9 +221,10 @@ where
     ///
     /// Panics if range `start >= end`.
     pub fn insert(&mut self, range: Range<K>, value: V) {
-        // We don't want to have to make empty ranges make sense;
-        // they don't represent anything meaningful in this structure.
-        assert!(range.start < range.end);
+        // A range is empty if start >= end, in that case inserting makes no sense.
+        if range.start >= range.end {
+            return;
+        }
 
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.


### PR DESCRIPTION
Currently, on insertion there are assertions to check for invalid ranges:

```rust
// RangeMap::insert
assert!(range.start < range.end);
```

```rust
// RangeInclusiveMap::insert
assert!(
    range.start() <= range.end(),
    "Range start can not be after range end"
);
```

I think it is fair to disallow such ranges, however using an assertion here might not be a good way to do this, as they are essentially panics. Since these empty ranges are representable using the `Range` and `RangeInclusive` types, I think it is not a good idea to panic here.

According to the standard library, a range is empty if start >= end:

>  It is empty unless start <= end.

An inclusive range is empty if start > end. While it makes no sense to insert such a range, I would suggest simply returning and not performing an insertion in this case.