### PR TITLE
Idea: use proptest additionally for unit testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rand = "0.8"
 chrono = "0.4" # For examples
 rustc_version = "0.4"
 serde_json = "1"
+proptest = "1.4.0"
+test-strategy = "0.3.1"
 
 [features]
 serde1 = ["serde"]

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -418,7 +418,30 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc as std;
     use alloc::{format, vec, vec::Vec};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn test_arbitrary_set_u8(ranges: Vec<RangeInclusive<u8>>) {
+        let ranges: Vec<_> = ranges
+            .into_iter()
+            .filter(|range| range.start() != range.end())
+            .collect();
+        let set = ranges
+            .iter()
+            .fold(RangeInclusiveSet::new(), |mut set, range| {
+                set.insert(range.clone());
+                set
+            });
+
+        for value in 0..u8::MAX {
+            assert_eq!(
+                set.contains(&value),
+                ranges.iter().any(|range| range.contains(&value))
+            );
+        }
+    }
 
     trait RangeInclusiveSetExt<T> {
         fn to_vec(&self) -> Vec<RangeInclusive<T>>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -745,7 +745,34 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::{format, vec, vec::Vec};
+    use alloc as std;
+    use alloc::{format, string::String, vec, vec::Vec};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn test_arbitrary_map_u8(ranges: Vec<(Range<u8>, String)>) {
+        let ranges: Vec<_> = ranges
+            .into_iter()
+            .filter(|(range, _value)| range.start != range.end)
+            .collect();
+        let set = ranges
+            .iter()
+            .fold(RangeMap::new(), |mut set, (range, value)| {
+                set.insert(range.clone(), value.clone());
+                set
+            });
+
+        for value in 0..u8::MAX {
+            assert_eq!(
+                set.get(&value),
+                ranges
+                    .iter()
+                    .rev()
+                    .find(|(range, _value)| range.contains(&value))
+                    .map(|(_range, value)| value)
+            );
+        }
+    }
 
     trait RangeMapExt<K, V> {
         fn to_vec(&self) -> Vec<(Range<K>, V)>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -387,6 +387,17 @@ where
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+    use test_strategy::proptest;
+    use alloc as std;
+
+    #[proptest]
+    fn test_arbitrary_set(ranges: Vec<Range<u16>>) {
+        let ranges: Vec<_> = ranges.into_iter().filter(|range| range.start != range.end).collect();
+        let mut set = ranges.iter().fold(RangeSet::new(), |mut set, range| {
+            set.insert(range.clone());
+            set
+        });
+    }
 
     trait RangeSetExt<T> {
         fn to_vec(&self) -> Vec<Range<T>>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -386,17 +386,27 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc as std;
     use alloc::{format, vec, vec::Vec};
     use test_strategy::proptest;
-    use alloc as std;
 
     #[proptest]
-    fn test_arbitrary_set(ranges: Vec<Range<u16>>) {
-        let ranges: Vec<_> = ranges.into_iter().filter(|range| range.start != range.end).collect();
-        let mut set = ranges.iter().fold(RangeSet::new(), |mut set, range| {
+    fn test_arbitrary_set_u8(ranges: Vec<Range<u8>>) {
+        let ranges: Vec<_> = ranges
+            .into_iter()
+            .filter(|range| range.start != range.end)
+            .collect();
+        let set = ranges.iter().fold(RangeSet::new(), |mut set, range| {
             set.insert(range.clone());
             set
         });
+
+        for value in 0..u8::MAX {
+            assert_eq!(
+                set.contains(&value),
+                ranges.iter().any(|range| range.contains(&value))
+            );
+        }
     }
 
     trait RangeSetExt<T> {


### PR DESCRIPTION
This one is more of a suggestion. I have not looked too deep into the tests, but it appears that rangemap is already very well-tested, and there is the option of using `cargo-fuzz` which is awesome.

I like to use `proptest` whenever possible, just because I quite like the interface and it gets a lot of the benefits of fuzzing for a cheaper "cost" in unit tests, and it has nice features such as test case simplification. I think it is worth using it, even if there is already a solid test interface.

This PR adds a simple proptest-based unit test for each of the set and map types as an example for how to use it. 

If you think this is useful, feel free to merge it. If not, also fine. However, it would be quite useful to have `proptest` in order to test the `intersection` functionality (that is the main reason I would like to add it).