### PR TITLE
Intersection and Union support for sets

### DIFF
--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -2,7 +2,7 @@ use crate::operations::{Intersection, Union};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::iter::{DoubleEndedIterator, FromIterator};
-use core::ops::RangeInclusive;
+use core::ops::{RangeInclusive, BitOr, BitAnd};
 
 #[cfg(feature = "serde1")]
 use core::marker::PhantomData;
@@ -449,6 +449,22 @@ macro_rules! range_inclusive_set {
     ($($range:expr),* $(,)?) => {{
         <$crate::RangeInclusiveSet<_> as core::iter::FromIterator<_>>::from_iter([$($range,)*])
     }};
+}
+
+impl<T: Ord + Clone + StepLite> BitAnd for &RangeInclusiveSet<T> {
+    type Output = RangeInclusiveSet<T>;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        self.intersection(other).collect()
+    }
+}
+
+impl<T: Ord + Clone + StepLite> BitOr for &RangeInclusiveSet<T> {
+    type Output = RangeInclusiveSet<T>;
+
+    fn bitor(self, other: Self) -> Self::Output {
+        self.union(other).collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,8 +1,7 @@
-use crate::operations::{Intersection, Union};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::iter::{DoubleEndedIterator, FromIterator};
-use core::ops::{RangeInclusive, BitOr, BitAnd};
+use core::ops::{BitAnd, BitOr, RangeInclusive};
 
 #[cfg(feature = "serde1")]
 use core::marker::PhantomData;
@@ -14,6 +13,12 @@ use serde::{
 
 use crate::std_ext::*;
 use crate::RangeInclusiveMap;
+
+/// Intersection iterator over two [`RangeInclusiveSet`].
+pub type Intersection<'a, T> = crate::operations::Intersection<'a, RangeInclusive<T>, Iter<'a, T>>;
+
+/// Union iterator over two [`RangeInclusiveSet`].
+pub type Union<'a, T> = crate::operations::Union<'a, RangeInclusive<T>, Iter<'a, T>>;
 
 #[derive(Clone, Hash, Default, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as ranges bounded
@@ -175,15 +180,12 @@ where
     }
 
     /// Iterator over the union of two range sets.
-    pub fn union<'a>(&'a self, other: &'a Self) -> Union<RangeInclusive<T>, Iter<'a, T>> {
+    pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
         Union::new(self.iter(), other.iter())
     }
 
     /// Iterator over the intersection of two range sets.
-    pub fn intersection<'a>(
-        &'a self,
-        other: &'a Self,
-    ) -> Intersection<RangeInclusive<T>, Iter<'a, T>> {
+    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection::new(self.iter(), other.iter())
     }
 }

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,3 +1,4 @@
+use crate::operations::{Intersection, Union};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::iter::{DoubleEndedIterator, FromIterator};
@@ -171,6 +172,19 @@ where
     /// set.
     pub fn last(&self) -> Option<&RangeInclusive<T>> {
         self.rm.last_range_value().map(|(range, _)| range)
+    }
+
+    /// Iterator over the union of two range sets.
+    pub fn union<'a>(&'a self, other: &'a Self) -> Union<RangeInclusive<T>, Iter<'a, T>> {
+        Union::new(self.iter(), other.iter())
+    }
+
+    /// Iterator over the intersection of two range sets.
+    pub fn intersection<'a>(
+        &'a self,
+        other: &'a Self,
+    ) -> Intersection<RangeInclusive<T>, Iter<'a, T>> {
+        Intersection::new(self.iter(), other.iter())
     }
 }
 
@@ -493,12 +507,17 @@ mod tests {
         assert_eq!(forward, backward);
     }
 
-    #[proptest]
-    fn test_arbitrary_set_u8(ranges: Vec<RangeInclusive<u8>>) {
-        let ranges: Vec<_> = ranges
+    // neccessary due to assertion on empty ranges
+    fn filter_ranges<T: Ord>(ranges: Vec<RangeInclusive<T>>) -> Vec<RangeInclusive<T>> {
+        ranges
             .into_iter()
             .filter(|range| range.start() != range.end())
-            .collect();
+            .collect()
+    }
+
+    #[proptest]
+    fn test_arbitrary_set_u8(ranges: Vec<RangeInclusive<u8>>) {
+        let ranges: Vec<_> = filter_ranges(ranges);
         let set = ranges
             .iter()
             .fold(RangeInclusiveSet::new(), |mut set, range| {
@@ -528,6 +547,69 @@ mod tests {
             range_inclusive_set![0..=100, 200..=300, 400..=500],
             [0..=100, 200..=300, 400..=500].iter().cloned().collect(),
         );
+    }
+
+    #[proptest]
+    fn test_union_overlaps_u8(left: Vec<RangeInclusive<u8>>, right: Vec<RangeInclusive<u8>>) {
+        let left: RangeInclusiveSet<_> = filter_ranges(left).into_iter().collect();
+        let right: RangeInclusiveSet<_> = filter_ranges(right).into_iter().collect();
+
+        let mut union = RangeInclusiveSet::new();
+        for range in left.union(&right) {
+            // there should not be any overlaps in the ranges returned by the union
+            assert!(union.overlapping(&range).next().is_none());
+            union.insert(range);
+        }
+    }
+
+    #[proptest]
+    fn test_union_contains_u8(left: Vec<RangeInclusive<u8>>, right: Vec<RangeInclusive<u8>>) {
+        let left: RangeInclusiveSet<_> = filter_ranges(left).into_iter().collect();
+        let right: RangeInclusiveSet<_> = filter_ranges(right).into_iter().collect();
+        let union: RangeInclusiveSet<_> = left.union(&right).collect();
+
+        // value should be in the union if and only if it is in either set
+        for value in 0..u8::MAX {
+            assert_eq!(
+                union.contains(&value),
+                left.contains(&value) || right.contains(&value)
+            );
+        }
+    }
+
+    #[proptest]
+    fn test_intersection_contains_u8(
+        left: Vec<RangeInclusive<u8>>,
+        right: Vec<RangeInclusive<u8>>,
+    ) {
+        let left: RangeInclusiveSet<_> = filter_ranges(left).into_iter().collect();
+        let right: RangeInclusiveSet<_> = filter_ranges(right).into_iter().collect();
+        let union: RangeInclusiveSet<_> = left.intersection(&right).collect();
+
+        // value should be in the union if and only if it is in either set
+        for value in 0..u8::MAX {
+            assert_eq!(
+                union.contains(&value),
+                left.contains(&value) && right.contains(&value)
+            );
+        }
+    }
+
+    #[proptest]
+    fn test_intersection_overlaps_u8(
+        left: Vec<RangeInclusive<u8>>,
+        right: Vec<RangeInclusive<u8>>,
+    ) {
+        let left: RangeInclusiveSet<_> = filter_ranges(left).into_iter().collect();
+        let right: RangeInclusiveSet<_> = filter_ranges(right).into_iter().collect();
+
+        let mut union = RangeInclusiveSet::new();
+        for range in left.intersection(&right) {
+            // there should not be any overlaps in the ranges returned by the
+            // intersection
+            assert!(union.overlapping(&range).next().is_none());
+            union.insert(range);
+        }
     }
 
     trait RangeInclusiveSetExt<T> {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -179,12 +179,12 @@ where
         self.rm.last_range_value().map(|(range, _)| range)
     }
 
-    /// Iterator over the union of two range sets.
+    /// Return an iterator over the union of two range sets.
     pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
         Union::new(self.iter(), other.iter())
     }
 
-    /// Iterator over the intersection of two range sets.
+    /// Return an iterator over the intersection of two range sets.
     pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection::new(self.iter(), other.iter())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ extern crate alloc;
 pub mod inclusive_map;
 pub mod inclusive_set;
 pub mod map;
+pub mod operations;
 pub mod set;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ extern crate alloc;
 pub mod inclusive_map;
 pub mod inclusive_set;
 pub mod map;
-pub mod operations;
+pub(crate) mod operations;
 pub mod set;
 
 #[cfg(test)]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,0 +1,246 @@
+use core::cmp::Ordering;
+use core::iter::{FusedIterator, Peekable};
+use core::ops::{Range, RangeInclusive};
+
+/// Trait to determine the ordering of the start and end of a range.
+trait RangeOrder {
+    /// Ordering of start value
+    fn order_start(&self, other: &Self) -> Ordering;
+
+    /// Ordering of end value
+    fn order_end(&self, other: &Self) -> Ordering;
+}
+
+impl<T: Ord> RangeOrder for Range<T> {
+    fn order_start(&self, other: &Self) -> Ordering {
+        self.start.cmp(&other.start)
+    }
+
+    fn order_end(&self, other: &Self) -> Ordering {
+        self.end.cmp(&other.end)
+    }
+}
+
+impl<T: Ord> RangeOrder for RangeInclusive<T> {
+    fn order_start(&self, other: &Self) -> Ordering {
+        self.start().cmp(other.start())
+    }
+
+    fn order_end(&self, other: &Self) -> Ordering {
+        self.end().cmp(&other.end())
+    }
+}
+
+/// Range which can be merged with a next range if they overlap.
+trait RangeMerge: Sized {
+    /// Attempt to merge the next range into the current range, if they overlap.
+    fn merge(&mut self, next: &Self) -> bool;
+}
+
+impl<T: Ord + Clone> RangeMerge for Range<T> {
+    fn merge(&mut self, other: &Self) -> bool {
+        if !self.contains(&other.start) {
+            return false;
+        }
+
+        if other.end > self.end {
+            self.end = other.end.clone();
+        }
+
+        true
+    }
+}
+
+impl<T: Ord + Clone> RangeMerge for RangeInclusive<T> {
+    fn merge(&mut self, other: &Self) -> bool {
+        if !self.contains(other.start()) {
+            return false;
+        }
+
+        if other.end() > self.end() {
+            *self = RangeInclusive::new(self.start().clone(), other.end().clone());
+        }
+
+        true
+    }
+}
+
+/// Range which can be merged with a next range if they overlap.
+trait RangeIntersect: Sized {
+    /// Attempt to merge the next range into the current range, if they overlap.
+    fn intersect(&self, next: &Self) -> Option<Self>;
+}
+
+impl<T: Ord + Clone> RangeIntersect for Range<T> {
+    fn intersect(&self, other: &Self) -> Option<Self> {
+        let start = (&self.start).max(&other.start);
+        let end = (&self.end).min(&other.end);
+
+        if start >= end {
+            return None;
+        }
+
+        Some(start.clone()..end.clone())
+    }
+}
+
+impl<T: Ord + Clone> RangeIntersect for RangeInclusive<T> {
+    fn intersect(&self, other: &Self) -> Option<Self> {
+        let start = self.start().max(other.start());
+        let end = self.end().min(other.end());
+
+        if start > end {
+            return None;
+        }
+
+        Some(start.clone()..=end.clone())
+    }
+}
+
+#[test]
+fn test_intersect() {
+    assert_eq!((0..5).intersect(&(0..3)), Some(0..3));
+    assert_eq!((0..3).intersect(&(0..5)), Some(0..3));
+    assert_eq!((0..3).intersect(&(3..3)), None);
+}
+
+/// Iterator that produces the union of two iterators of sorted ranges.
+pub struct Union<'a, T, L, R = L>
+where
+    T: 'a,
+    L: Iterator<Item = &'a T>,
+    R: Iterator<Item = &'a T>,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+}
+
+impl<'a, T, L, R> Union<'a, T, L, R>
+where
+    T: 'a,
+    L: Iterator<Item = &'a T>,
+    R: Iterator<Item = &'a T>,
+{
+    /// Create new Union iterator.
+    ///
+    /// Requires that the two iterators produce sorted ranges.
+    pub fn new(left: L, right: R) -> Self {
+        Self {
+            left: left.peekable(),
+            right: right.peekable(),
+        }
+    }
+}
+
+impl<'a, R, I> Iterator for Union<'a, R, I>
+where
+    R: RangeOrder + RangeMerge + Clone,
+    I: Iterator<Item = &'a R>,
+{
+    type Item = R;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // get start range
+        let mut range = match (self.left.peek(), self.right.peek()) {
+            // if there is only one possible range, pick that
+            (Some(_), None) => self.left.next().unwrap(),
+            (None, Some(_)) => self.right.next().unwrap(),
+            // when there are two ranges, pick the one with the earlier start
+            (Some(left), Some(right)) => {
+                if left.order_start(right).is_lt() {
+                    self.left.next().unwrap()
+                } else {
+                    self.right.next().unwrap()
+                }
+            }
+            // otherwise we are done
+            (None, None) => return None,
+        }
+        .clone();
+
+        // peek into next value of iterator and merge if it is contiguous
+        let mut join = |iter: &mut Peekable<I>| {
+            if let Some(next) = iter.peek() {
+                if range.merge(next) {
+                    iter.next().unwrap();
+                    return true;
+                }
+            }
+            false
+        };
+
+        // keep merging ranges as long as we can
+        loop {
+            if !(join(&mut self.left) || join(&mut self.right)) {
+                break;
+            }
+        }
+
+        Some(range)
+    }
+}
+
+impl<'a, R, I> FusedIterator for Union<'a, R, I>
+where
+    R: RangeOrder + RangeMerge + Clone,
+    I: Iterator<Item = &'a R>,
+{
+}
+
+/// Iterator that produces the union of two iterators of sorted ranges.
+pub struct Intersection<'a, T, L, R = L>
+where
+    T: 'a,
+    L: Iterator<Item = &'a T>,
+    R: Iterator<Item = &'a T>,
+{
+    left: Peekable<L>,
+    right: Peekable<R>,
+}
+
+impl<'a, T, L, R> Intersection<'a, T, L, R>
+where
+    T: 'a,
+    L: Iterator<Item = &'a T>,
+    R: Iterator<Item = &'a T>,
+{
+    /// Create new Intersection iterator.
+    ///
+    /// Requires that the two iterators produce sorted ranges.
+    pub fn new(left: L, right: R) -> Self {
+        Self {
+            left: left.peekable(),
+            right: right.peekable(),
+        }
+    }
+}
+
+impl<'a, R, I> Iterator for Intersection<'a, R, I>
+where
+    R: RangeOrder + RangeIntersect + Clone,
+    I: Iterator<Item = &'a R>,
+{
+    type Item = R;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // if we don't have at least two ranges, there cannot be an intersection
+            let (Some(left), Some(right)) = (self.left.peek(), self.right.peek()) else {
+                return None;
+            };
+
+            let intersection = left.intersect(right);
+
+            // pop the range that ends earlier
+            if left.order_end(right).is_lt() {
+                self.left.next();
+            } else {
+                self.right.next();
+            }
+
+            if let Some(intersection) = intersection {
+                return Some(intersection);
+            }
+        }
+    }
+}

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -33,7 +33,7 @@ impl<T: Ord> RangeOrder for RangeInclusive<T> {
 
 /// Range which can be merged with a next range if they overlap.
 trait RangeMerge: Sized {
-    /// Attempt to merge the next range into the current range, if they overlap.
+    /// Merges this range and the next range, if they overlap.
     fn merge(&mut self, next: &Self) -> bool;
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -84,12 +84,12 @@ where
         self.rm.is_empty()
     }
 
-    /// Iterator over the intersection of two range sets.
+    /// Return an iterator over the intersection of two range sets.
     pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection::new(self.iter(), other.iter())
     }
 
-    /// Iterator over the union of two range sets.
+    /// Return an iterator over the union of two range sets.
     pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
         Union::new(self.iter(), other.iter())
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,8 +1,8 @@
 use crate::operations::{Intersection, Union};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
-use core::iter::{DoubleEndedIterator, FromIterator};
-use core::ops::Range;
+use core::iter::FromIterator;
+use core::ops::{BitAnd, BitOr, Range};
 use core::prelude::v1::*;
 
 #[cfg(feature = "serde1")]
@@ -386,6 +386,22 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(|(k, _v)| k)
+    }
+}
+
+impl<T: Ord + Clone> BitAnd for &RangeSet<T> {
+    type Output = RangeSet<T>;
+
+    fn bitand(self, other: Self) -> Self::Output {
+        self.intersection(other).collect()
+    }
+}
+
+impl<T: Ord + Clone> BitOr for &RangeSet<T> {
+    type Output = RangeSet<T>;
+
+    fn bitor(self, other: Self) -> Self::Output {
+        self.union(other).collect()
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,3 @@
-use crate::operations::{Intersection, Union};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
@@ -14,6 +13,12 @@ use serde::{
 };
 
 use crate::RangeMap;
+
+/// Intersection iterator over two [`RangeSet`].
+pub type Intersection<'a, T> = crate::operations::Intersection<'a, Range<T>, Iter<'a, T>>;
+
+/// Union iterator over two [`RangeSet`].
+pub type Union<'a, T> = crate::operations::Union<'a, Range<T>, Iter<'a, T>>;
 
 #[derive(Clone, Hash, Default, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as (half-open) ranges bounded
@@ -80,12 +85,12 @@ where
     }
 
     /// Iterator over the intersection of two range sets.
-    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, Range<T>, Iter<'a, T>> {
+    pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection::new(self.iter(), other.iter())
     }
 
     /// Iterator over the union of two range sets.
-    pub fn union<'a>(&'a self, other: &'a Self) -> Union<Range<T>, Iter<'a, T>> {
+    pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
         Union::new(self.iter(), other.iter())
     }
 


### PR DESCRIPTION
This PR adds the ability to determine both the intersection as well as the union of two sets. It attempts to be relatively generic, working for any iterator pairs that produce sorted, but not necessarily non-overlapping ranges. 

It tries to be efficient by doing the least amount of work necessary, and correct in that it will join overlapping ranges correctly. 

Correctness is verified using randomized test cases with proptest. So far, there are test cases for:

- [x] correctness of union: the union of two sets contains a value if and only if either or both of the two sets contain it
- [x] correct merging of ranges: the union iterator of sets never produces overlapping ranges
- [x] correctness of intersection: the intersection of two sets contains a value if and only if both of the two sets contain it
- [x] correct merging of intersection: the intersection iterator never produces overlapping ranges

By validating these four assumptions, we have a guarantee that the code is correct.