### PR TITLE
Adds a literal macro for each of the range types.

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -849,6 +849,25 @@ impl<K: Ord + Clone + StepLite, V: Eq + Clone, const N: usize> From<[(RangeInclu
     }
 }
 
+/// Create a [`RangeInclusiveMap`] from key-value pairs.
+///
+/// # Example
+///
+/// ```rust
+/// # use rangemap::range_inclusive_map;
+/// let map = range_inclusive_map!{
+///     0..=100 => "abc",
+///     100..=200 => "def",
+///     200..=300 => "ghi"
+/// };
+/// ```
+#[macro_export]
+macro_rules! range_inclusive_map {
+    ($($k:expr => $v:expr),* $(,)?) => {{
+        <$crate::RangeInclusiveMap<_, _> as core::iter::FromIterator<_>>::from_iter([$(($k, $v),)*])
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -889,6 +908,17 @@ mod tests {
         assert_eq!(
             map,
             RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")])
+        );
+    }
+
+    #[test]
+    fn test_macro() {
+        assert_eq!(
+            range_inclusive_map!(0..=100 => "abc", 100..=200 => "def", 200..=300 => "ghi"),
+            [(0..=100, "abc"), (100..=200, "def"), (200..=300, "ghi")]
+                .iter()
+                .cloned()
+                .collect(),
         );
     }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -418,6 +418,21 @@ impl<T: Ord + Clone + StepLite, const N: usize> From<[RangeInclusive<T>; N]>
     }
 }
 
+/// Create a [`RangeInclusiveSet`] from a list of ranges.
+///
+/// # Example
+///
+/// ```rust
+/// # use rangemap::range_inclusive_set;
+/// let set = range_inclusive_set![0..=100, 200..=300, 400..=500];
+/// ```
+#[macro_export]
+macro_rules! range_inclusive_set {
+    ($($range:expr),* $(,)?) => {{
+        <$crate::RangeInclusiveSet<_> as core::iter::FromIterator<_>>::from_iter([$($range,)*])
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,6 +467,14 @@ mod tests {
         set.insert(0..=100);
         set.insert(200..=300);
         assert_eq!(set, RangeInclusiveSet::from([0..=100, 200..=300]));
+    }
+
+    #[test]
+    fn test_macro() {
+        assert_eq!(
+            range_inclusive_set![0..=100, 200..=300, 400..=500],
+            [0..=100, 200..=300, 400..=500].iter().cloned().collect(),
+        );
     }
 
     trait RangeInclusiveSetExt<T> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -739,6 +739,25 @@ impl<K: Ord + Clone, V: Eq + Clone, const N: usize> From<[(Range<K>, V); N]> for
     }
 }
 
+/// Create a [`RangeMap`] from key-value pairs.
+///
+/// # Example
+///
+/// ```rust
+/// # use rangemap::range_map;
+/// let map = range_map!{
+///     0..100 => "abc",
+///     100..200 => "def",
+///     200..300 => "ghi"
+/// };
+/// ```
+#[macro_export]
+macro_rules! range_map {
+    ($($k:expr => $v:expr),* $(,)?) => {{
+        <$crate::RangeMap<_, _> as core::iter::FromIterator<_>>::from_iter([$(($k, $v),)*])
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -779,6 +798,17 @@ mod tests {
         assert_eq!(
             map,
             RangeMap::from([(0..100, "hello"), (200..300, "world")])
+        );
+    }
+
+    #[test]
+    fn test_macro() {
+        assert_eq!(
+            range_map!(0..100 => "abc", 100..200 => "def", 200..300 => "ghi"),
+            [(0..100, "abc"), (100..200, "def"), (200..300, "ghi")]
+                .iter()
+                .cloned()
+                .collect(),
         );
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -352,6 +352,21 @@ impl<T: Ord + Clone, const N: usize> From<[Range<T>; N]> for RangeSet<T> {
     }
 }
 
+/// Create a [`RangeSet`] from a list of ranges.
+///
+/// # Example
+///
+/// ```rust
+/// # use rangemap::range_set;
+/// let set = range_set![0..100, 200..300, 400..500];
+/// ```
+#[macro_export]
+macro_rules! range_set {
+    ($($range:expr),* $(,)?) => {{
+        <$crate::RangeSet<_> as core::iter::FromIterator<_>>::from_iter([$($range,)*])
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,6 +399,14 @@ mod tests {
         set.insert(0..100);
         set.insert(200..300);
         assert_eq!(set, RangeSet::from([0..100, 200..300]));
+    }
+
+    #[test]
+    fn test_macro() {
+        assert_eq!(
+            range_set![0..100, 200..300, 400..500],
+            [0..100, 200..300, 400..500].iter().cloned().collect(),
+        );
     }
 
     trait RangeSetExt<T> {


### PR DESCRIPTION
This addresses issue #66 by adding macros for each of the range map data types.

For example:

```rust
use rangemap::{range_map, range_set};

// map literal
let map = range_map!{
    0..100 => "abc",
    200..300 => "def",
};

// set literal
let set = range_set![0..100, 300..400];
```

These macros are exported, documented and tested.

<img width="622" alt="Screenshot 2024-02-05 at 09 09 08" src="https://github.com/jeffparsons/rangemap/assets/786420/6bb79f76-ba93-485f-998c-245ac97569ee">
