### PR TITLE
Implements `From<[_; T]>` for set and maps

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -847,10 +847,33 @@ where
     }
 }
 
+impl<K: Ord + Clone + StepLite, V: Eq + Clone, const N: usize> From<[(RangeInclusive<K>, V); N]>
+    for RangeInclusiveMap<K, V>
+{
+    fn from(value: [(RangeInclusive<K>, V); N]) -> Self {
+        let mut map = Self::new();
+        for (range, value) in IntoIterator::into_iter(value) {
+            map.insert(range, value);
+        }
+        map
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+
+    #[test]
+    fn test_from_array() {
+        let mut map = RangeInclusiveMap::new();
+        map.insert(0..=100, "hello");
+        map.insert(200..=300, "world");
+        assert_eq!(
+            map,
+            RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")])
+        );
+    }
 
     trait RangeInclusiveMapExt<K, V> {
         fn to_vec(&self) -> Vec<(RangeInclusive<K>, V)>;

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -415,10 +415,30 @@ where
     }
 }
 
+impl<T: Ord + Clone + StepLite, const N: usize> From<[RangeInclusive<T>; N]>
+    for RangeInclusiveSet<T>
+{
+    fn from(value: [RangeInclusive<T>; N]) -> Self {
+        let mut set = Self::new();
+        for value in IntoIterator::into_iter(value) {
+            set.insert(value);
+        }
+        set
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+
+    #[test]
+    fn test_from_array() {
+        let mut set = RangeInclusiveSet::new();
+        set.insert(0..=100);
+        set.insert(200..=300);
+        assert_eq!(set, RangeInclusiveSet::from([0..=100, 200..=300]));
+    }
 
     trait RangeInclusiveSetExt<T> {
         fn to_vec(&self) -> Vec<RangeInclusive<T>>;

--- a/src/map.rs
+++ b/src/map.rs
@@ -742,10 +742,31 @@ where
     }
 }
 
+impl<K: Ord + Clone, V: Eq + Clone, const N: usize> From<[(Range<K>, V); N]> for RangeMap<K, V> {
+    fn from(value: [(Range<K>, V); N]) -> Self {
+        let mut map = Self::new();
+        for (range, value) in IntoIterator::into_iter(value) {
+            map.insert(range, value);
+        }
+        map
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+
+    #[test]
+    fn test_from_array() {
+        let mut map = RangeMap::new();
+        map.insert(0..100, "hello");
+        map.insert(200..300, "world");
+        assert_eq!(
+            map,
+            RangeMap::from([(0..100, "hello"), (200..300, "world")])
+        );
+    }
 
     trait RangeMapExt<K, V> {
         fn to_vec(&self) -> Vec<(Range<K>, V)>;

--- a/src/set.rs
+++ b/src/set.rs
@@ -383,10 +383,28 @@ where
     }
 }
 
+impl<T: Ord + Clone, const N: usize> From<[Range<T>; N]> for RangeSet<T> {
+    fn from(value: [Range<T>; N]) -> Self {
+        let mut set = Self::new();
+        for value in IntoIterator::into_iter(value) {
+            set.insert(value);
+        }
+        set
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::{format, vec, vec::Vec};
+
+    #[test]
+    fn test_from_array() {
+        let mut set = RangeSet::new();
+        set.insert(0..100);
+        set.insert(200..300);
+        assert_eq!(set, RangeSet::from([0..100, 200..300]));
+    }
 
     trait RangeSetExt<T> {
         fn to_vec(&self) -> Vec<Range<T>>;


### PR DESCRIPTION
This implements:

- `From<[Range<T>; N]>` for `RangeSet<T>`
- `From<[RangeInclusive<T>; N]>` for `RangeInclusiveSet<T>`
- `From<[(Range<K>, V); N]>` for `RangeMap<K, V>`
- `From<[(RangeInclusive<K>, V); N]>` for `RangeInclusiveMap<K, V>`

These implementations make it simpler to construct values, simply with this:

```rust
let set = RangeSet::from([0..100, 200..300]);
let set_inclusive = RangeInclusiveSet::from([0..=100, 200..=300]);
let map = RangeMap::from([(0..100, "hello"), (200..300, "world")]);
let map_inclusive = RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")]);
```

There are passing unit tests for each of these trait implementations.

This addresses #82.