### PR TITLE
Implements `DoubleEndedIterator` for all iterators and implements `first()` and `last()` API

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -873,6 +873,27 @@ where
     }
 }
 
+impl<'a, K, V, R: Borrow<RangeInclusive<K>>> DoubleEndedIterator for Overlapping<'a, K, V, R>
+where
+    K: Ord + Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some((k, v)) = self.btm_range_iter.next_back() {
+            if k.start() <= self.query_range.borrow().end() {
+                Some((&k.range, v))
+            } else {
+                // The rest of the items in the underlying iterator
+                // are past the query range. We can keep taking items
+                // from that iterator and this will remain true,
+                // so this is enough to make the iterator fused.
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
 impl<K: Ord + Clone + StepLite, V: Eq + Clone, const N: usize> From<[(RangeInclusive<K>, V); N]>
     for RangeInclusiveMap<K, V>
 {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -878,19 +878,13 @@ where
     K: Ord + Clone,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some((k, v)) = self.btm_range_iter.next_back() {
+        while let Some((k, v)) = self.btm_range_iter.next_back() {
             if k.start() <= self.query_range.borrow().end() {
-                Some((&k.range, v))
-            } else {
-                // The rest of the items in the underlying iterator
-                // are past the query range. We can keep taking items
-                // from that iterator and this will remain true,
-                // so this is enough to make the iterator fused.
-                None
+                return Some((&k.range, v));
             }
-        } else {
-            None
         }
+
+        None
     }
 }
 
@@ -957,6 +951,17 @@ mod tests {
     fn test_into_iter_reversible(set: RangeInclusiveMap<u64, String>) {
         let forward: Vec<_> = set.clone().into_iter().collect();
         let mut backward: Vec<_> = set.into_iter().rev().collect();
+        backward.reverse();
+        assert_eq!(forward, backward);
+    }
+
+    #[proptest]
+    fn test_overlapping_reversible(
+        set: RangeInclusiveMap<u64, String>,
+        range: RangeInclusive<u64>,
+    ) {
+        let forward: Vec<_> = set.overlapping(&range).collect();
+        let mut backward: Vec<_> = set.overlapping(&range).rev().collect();
         backward.reverse();
         assert_eq!(forward, backward);
     }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -909,9 +909,9 @@ impl<K: Ord + Clone + StepLite, V: Eq + Clone, const N: usize> From<[(RangeInclu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::{format, vec, vec::Vec, string::String};
-    use test_strategy::proptest;
     use alloc as std;
+    use alloc::{format, string::String, vec, vec::Vec};
+    use test_strategy::proptest;
 
     #[proptest]
     fn test_arbitrary_map_u8(ranges: Vec<(RangeInclusive<u8>, String)>) {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -544,13 +544,17 @@ where
     /// Returns the first range-value pair in this map, if one exists. The range in this pair is the
     /// minimum range in the map.
     pub fn first_range_value(&self) -> Option<(&RangeInclusive<K>, &V)> {
-        self.btm.first_key_value().map(|(range, value)| (&range.end_wrapper.range, value))
+        self.btm
+            .first_key_value()
+            .map(|(range, value)| (&range.end_wrapper.range, value))
     }
 
     /// Returns the last range-value pair in this map, if one exists. The range in this pair is the
     /// maximum range in the map.
     pub fn last_range_value(&self) -> Option<(&RangeInclusive<K>, &V)> {
-        self.btm.last_key_value().map(|(range, value)| (&range.end_wrapper.range, value))
+        self.btm
+            .last_key_value()
+            .map(|(range, value)| (&range.end_wrapper.range, value))
     }
 }
 
@@ -625,6 +629,14 @@ impl<K, V> Iterator for IntoIter<K, V> {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(range, value)| (range.end_wrapper.range, value))
     }
 }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -503,7 +503,6 @@ mod tests {
     }
 
     #[proptest]
-    #[ignore = "broken"]
     fn test_overlapping_reversible(set: RangeInclusiveSet<u64>, range: RangeInclusive<u64>) {
         let forward: Vec<_> = set.overlapping(&range).collect();
         let mut backward: Vec<_> = set.overlapping(&range).rev().collect();

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -1,7 +1,7 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
-use core::iter::FromIterator;
+use core::iter::{DoubleEndedIterator, FromIterator};
 use core::ops::RangeInclusive;
 
 #[cfg(feature = "serde1")]
@@ -192,6 +192,18 @@ where
     pub fn overlaps(&self, range: &RangeInclusive<T>) -> bool {
         self.overlapping(range).next().is_some()
     }
+
+    /// Returns the first range in the set, if one exists. The range is the minimum range in this
+    /// set.
+    pub fn first(&self) -> Option<&RangeInclusive<T>> {
+        self.rm.first_range_value().map(|(range, _)| range)
+    }
+
+    /// Returns the last range in the set, if one exists. The range is the minimum range in this
+    /// set.
+    pub fn last(&self) -> Option<&RangeInclusive<T>> {
+        self.rm.last_range_value().map(|(range, _)| range)
+    }
 }
 
 /// An iterator over the ranges of a `RangeInclusiveSet`.
@@ -207,12 +219,23 @@ pub struct Iter<'a, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a RangeInclusive<T>;
 
-    fn next(&mut self) -> Option<&'a RangeInclusive<T>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(range, _)| range)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<'a, K> DoubleEndedIterator for Iter<'a, K>
+where
+    K: 'a,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(range, _)| range)
     }
 }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -199,7 +199,7 @@ where
         self.rm.first_range_value().map(|(range, _)| range)
     }
 
-    /// Returns the last range in the set, if one exists. The range is the minimum range in this
+    /// Returns the last range in the set, if one exists. The range is the maximum range in this
     /// set.
     pub fn last(&self) -> Option<&RangeInclusive<T>> {
         self.rm.last_range_value().map(|(range, _)| range)

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -433,6 +433,15 @@ where
     }
 }
 
+impl<'a, T, R: Borrow<RangeInclusive<T>>> DoubleEndedIterator for Overlapping<'a, T, R>
+where
+    T: Ord + Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(k, _v)| k)
+    }
+}
+
 impl<T: Ord + Clone + StepLite, const N: usize> From<[RangeInclusive<T>; N]>
     for RangeInclusiveSet<T>
 {

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -233,9 +233,7 @@ where
     K: 'a,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.inner
-            .next_back()
-            .map(|(range, _)| range)
+        self.inner.next_back().map(|(range, _)| range)
     }
 }
 
@@ -266,6 +264,12 @@ impl<T> Iterator for IntoIter<T> {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<K> DoubleEndedIterator for IntoIter<K> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(range, _)| range)
     }
 }
 

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -462,11 +462,14 @@ mod tests {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
-    impl<T: Ord + Clone + StepLite + Debug + Arbitrary + 'static> Arbitrary for RangeInclusiveSet<T> {
+    impl<T> Arbitrary for RangeInclusiveSet<T>
+    where
+        T: Ord + Clone + StepLite + Debug + Arbitrary + 'static,
+    {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
 
-        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+        fn arbitrary_with(_parameters: Self::Parameters) -> Self::Strategy {
             any::<Vec<RangeInclusive<T>>>()
                 .prop_map(|ranges| ranges.into_iter().collect::<RangeInclusiveSet<T>>())
                 .boxed()
@@ -527,10 +530,6 @@ mod tests {
                 ranges.iter().any(|range| range.contains(&value))
             );
         }
-    }
-
-    fn collect<T: Ord + Clone + StepLite>(input: Vec<RangeInclusive<T>>) -> RangeInclusiveSet<T> {
-        input.into_iter().collect()
     }
 
     #[test]

--- a/src/map.rs
+++ b/src/map.rs
@@ -765,6 +765,27 @@ where
     }
 }
 
+impl<'a, K, V, R: Borrow<Range<K>>> DoubleEndedIterator for Overlapping<'a, K, V, R>
+where
+    K: Ord,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some((k, v)) = self.btm_range_iter.next_back() {
+            if k.start < self.query_range.borrow().end {
+                Some((&k.range, v))
+            } else {
+                // The rest of the items in the underlying iterator
+                // are past the query range. We can keep taking items
+                // from that iterator and this will remain true,
+                // so this is enough to make the iterator fused.
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
 impl<K: Ord + Clone, V: Eq + Clone, const N: usize> From<[(Range<K>, V); N]> for RangeMap<K, V> {
     fn from(value: [(Range<K>, V); N]) -> Self {
         let mut map = Self::new();

--- a/src/map.rs
+++ b/src/map.rs
@@ -191,13 +191,17 @@ where
     /// Returns the first range-value pair in this map, if one exists. The range in this pair is the
     /// minimum range in the map.
     pub fn first_range_value(&self) -> Option<(&Range<K>, &V)> {
-        self.btm.first_key_value().map(|(range, value)| (&range.end_wrapper.range, value))
+        self.btm
+            .first_key_value()
+            .map(|(range, value)| (&range.end_wrapper.range, value))
     }
 
     /// Returns the last range-value pair in this map, if one exists. The range in this pair is the
     /// maximum range in the map.
     pub fn last_range_value(&self) -> Option<(&Range<K>, &V)> {
-        self.btm.last_key_value().map(|(range, value)| (&range.end_wrapper.range, value))
+        self.btm
+            .last_key_value()
+            .map(|(range, value)| (&range.end_wrapper.range, value))
     }
 }
 
@@ -548,6 +552,14 @@ impl<K, V> Iterator for IntoIter<K, V> {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(range, value)| (range.end_wrapper.range, value))
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -393,14 +393,17 @@ mod tests {
     use super::*;
     use alloc as std;
     use alloc::{format, vec, vec::Vec};
-    use test_strategy::proptest;
     use proptest::prelude::*;
+    use test_strategy::proptest;
 
-    impl<T: Ord + Clone + Debug + Arbitrary + 'static> Arbitrary for RangeSet<T> {
+    impl<T> Arbitrary for RangeSet<T>
+    where
+        T: Ord + Clone + Debug + Arbitrary + 'static,
+    {
         type Parameters = ();
         type Strategy = BoxedStrategy<Self>;
 
-        fn arbitrary_with(parameters: Self::Parameters) -> Self::Strategy {
+        fn arbitrary_with(_parameters: Self::Parameters) -> Self::Strategy {
             any::<Vec<Range<T>>>()
                 .prop_map(|ranges| ranges.into_iter().collect::<RangeSet<T>>())
                 .boxed()

--- a/src/set.rs
+++ b/src/set.rs
@@ -369,6 +369,15 @@ where
     }
 }
 
+impl<'a, T, R: Borrow<Range<T>>> DoubleEndedIterator for Overlapping<'a, T, R>
+where
+    T: Ord + Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(k, _v)| k)
+    }
+}
+
 impl<T: Ord + Clone, const N: usize> From<[Range<T>; N]> for RangeSet<T> {
     fn from(value: [Range<T>; N]) -> Self {
         let mut set = Self::new();

--- a/src/set.rs
+++ b/src/set.rs
@@ -141,7 +141,7 @@ where
         self.rm.first_range_value().map(|(range, _)| range)
     }
 
-    /// Returns the last range in the set, if one exists. The range is the minimum range in this
+    /// Returns the last range in the set, if one exists. The range is the maximum range in this
     /// set.
     pub fn last(&self) -> Option<&Range<T>> {
         self.rm.last_range_value().map(|(range, _)| range)

--- a/src/set.rs
+++ b/src/set.rs
@@ -437,7 +437,6 @@ mod tests {
     }
 
     #[proptest]
-    #[ignore = "broken"]
     fn test_overlapping_reversible(set: RangeSet<u64>, range: Range<u64>) {
         let forward: Vec<_> = set.overlapping(&range).collect();
         let mut backward: Vec<_> = set.overlapping(&range).rev().collect();

--- a/src/set.rs
+++ b/src/set.rs
@@ -175,9 +175,7 @@ where
     K: 'a,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.inner
-            .next_back()
-            .map(|(range, _)| range)
+        self.inner.next_back().map(|(range, _)| range)
     }
 }
 
@@ -208,6 +206,12 @@ impl<T> Iterator for IntoIter<T> {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<K> DoubleEndedIterator for IntoIter<K> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(range, _)| range)
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,6 +1,6 @@
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
-use core::iter::FromIterator;
+use core::iter::{DoubleEndedIterator, FromIterator};
 use core::ops::Range;
 use core::prelude::v1::*;
 
@@ -134,6 +134,18 @@ where
     pub fn overlaps(&self, range: &Range<T>) -> bool {
         self.overlapping(range).next().is_some()
     }
+
+    /// Returns the first range in the set, if one exists. The range is the minimum range in this
+    /// set.
+    pub fn first(&self) -> Option<&Range<T>> {
+        self.rm.first_range_value().map(|(range, _)| range)
+    }
+
+    /// Returns the last range in the set, if one exists. The range is the minimum range in this
+    /// set.
+    pub fn last(&self) -> Option<&Range<T>> {
+        self.rm.last_range_value().map(|(range, _)| range)
+    }
 }
 
 /// An iterator over the ranges of a `RangeSet`.
@@ -149,12 +161,23 @@ pub struct Iter<'a, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a Range<T>;
 
-    fn next(&mut self) -> Option<&'a Range<T>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(range, _)| range)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+}
+
+impl<'a, K> DoubleEndedIterator for Iter<'a, K>
+where
+    K: 'a,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(range, _)| range)
     }
 }
 


### PR DESCRIPTION
This addresses #81 by implementing `DoubleEndedIterator` for the map and set types and adding `first()` and `last()` API functions where appropriate.

- [x] Implements `DoubleEndedIterator` for the `Iter` iterators
- [x] Implements `DoubleEndedIterator` for the `IntoIter` iterators
- [x] Adds `first()` and `last()` API for all set types
- [x] Adds `first_range_key()` and `last_range_key()` API for all map types
- [x] Implements `DoubleEndedIterator` for all `Overlapping` iterators
- [x] Implements `proptest::Arbitrary` for `RangeMap`, `RangeSet`, `RangeInclusiveMap`, `RangeInclusiveMap`
- [x] Adds tests for all iterators
- [x] Adds tests for all introduced API methods

As a side-effect, this PR implements `Arbitrary` for all of the set and map types. This allows for writing more concise proptests, which I think are quite readable.