### PR TITLE
Various fixes

### DIFF
--- a/examples/roster.rs
+++ b/examples/roster.rs
@@ -7,7 +7,7 @@ fn main() {
     let mut roster = RangeMap::new();
 
     // Set up initial roster.
-    let start_of_roster = Utc.ymd(2019, 1, 7);
+    let start_of_roster = Utc.with_ymd_and_hms(2019, 1, 7, 0, 0, 0).unwrap();
     let mut week_start = start_of_roster;
     for _ in 0..3 {
         for person in &people {

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -931,7 +931,7 @@ impl<K: Ord + Clone + StepLite, V: Eq + Clone, const N: usize> From<[(RangeInclu
 #[macro_export]
 macro_rules! range_inclusive_map {
     ($($k:expr => $v:expr),* $(,)?) => {{
-        <$crate::RangeInclusiveMap<_, _> as core::iter::FromIterator<_>>::from_iter([$(($k, $v),)*])
+        $crate::RangeInclusiveMap::from([$(($k, $v)),*])
     }};
 }
 
@@ -1039,6 +1039,7 @@ mod tests {
 
     #[test]
     fn test_macro() {
+        assert_eq!(range_inclusive_map![], RangeInclusiveMap::<i64, i64>::new());
         assert_eq!(
             range_inclusive_map!(0..=100 => "abc", 100..=200 => "def", 200..=300 => "ghi"),
             [(0..=100, "abc"), (100..=200, "def"), (200..=300, "ghi")]

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -449,7 +449,7 @@ impl<T: Ord + Clone + StepLite, const N: usize> From<[RangeInclusive<T>; N]>
 #[macro_export]
 macro_rules! range_inclusive_set {
     ($($range:expr),* $(,)?) => {{
-        <$crate::RangeInclusiveSet<_> as core::iter::FromIterator<_>>::from_iter([$($range,)*])
+        $crate::RangeInclusiveSet::from([$($range),*])
     }};
 }
 
@@ -561,6 +561,7 @@ mod tests {
 
     #[test]
     fn test_macro() {
+        assert_eq!(range_inclusive_set![], RangeInclusiveSet::<i64>::new());
         assert_eq!(
             range_inclusive_set![0..=100, 200..=300, 400..=500],
             [0..=100, 200..=300, 400..=500].iter().cloned().collect(),

--- a/src/map.rs
+++ b/src/map.rs
@@ -819,7 +819,7 @@ impl<K: Ord + Clone, V: Eq + Clone, const N: usize> From<[(Range<K>, V); N]> for
 #[macro_export]
 macro_rules! range_map {
     ($($k:expr => $v:expr),* $(,)?) => {{
-        <$crate::RangeMap<_, _> as core::iter::FromIterator<_>>::from_iter([$(($k, $v),)*])
+        $crate::RangeMap::from([$(($k, $v)),*])
     }};
 }
 
@@ -924,6 +924,7 @@ mod tests {
 
     #[test]
     fn test_macro() {
+        assert_eq!(range_map![], RangeMap::<i64, i64>::new());
         assert_eq!(
             range_map!(0..100 => "abc", 100..200 => "def", 200..300 => "ghi"),
             [(0..100, "abc"), (100..200, "def"), (200..300, "ghi")]

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -27,7 +27,7 @@ impl<T: Ord> RangeOrder for RangeInclusive<T> {
     }
 
     fn order_end(&self, other: &Self) -> Ordering {
-        self.end().cmp(&other.end())
+        self.end().cmp(other.end())
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -431,7 +431,7 @@ impl<T: Ord + Clone, const N: usize> From<[Range<T>; N]> for RangeSet<T> {
 #[macro_export]
 macro_rules! range_set {
     ($($range:expr),* $(,)?) => {{
-        <$crate::RangeSet<_> as core::iter::FromIterator<_>>::from_iter([$($range,)*])
+        $crate::RangeSet::from([$($range),*])
     }};
 }
 
@@ -525,6 +525,7 @@ mod tests {
 
     #[test]
     fn test_macro() {
+        assert_eq!(range_set![], RangeSet::<i64>::new());
         assert_eq!(
             range_set![0..100, 200..300, 400..500],
             [0..100, 200..300, 400..500].iter().cloned().collect(),


### PR DESCRIPTION
- Removes clippy warning about needless borrow
- Changes to using non-deprecated chrono function in example
- Switches to using `From<[T]>` implementation for macro
- Tests empty macro invocation