### PR TITLE
Allow clippy::len_zero when we really mean it

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -959,6 +959,7 @@ mod tests {
     }
 
     #[proptest]
+    #[allow(clippy::len_zero)]
     fn test_len(mut map: RangeInclusiveMap<u64, String>) {
         assert_eq!(map.len(), map.iter().count());
         assert_eq!(map.is_empty(), map.len() == 0);

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -497,6 +497,7 @@ mod tests {
     }
 
     #[proptest]
+    #[allow(clippy::len_zero)]
     fn test_len(mut map: RangeInclusiveSet<u64>) {
         assert_eq!(map.len(), map.iter().count());
         assert_eq!(map.is_empty(), map.len() == 0);

--- a/src/map.rs
+++ b/src/map.rs
@@ -855,6 +855,7 @@ mod tests {
     }
 
     #[proptest]
+    #[allow(clippy::len_zero)]
     fn test_len(mut map: RangeMap<u64, String>) {
         assert_eq!(map.len(), map.iter().count());
         assert_eq!(map.is_empty(), map.len() == 0);

--- a/src/set.rs
+++ b/src/set.rs
@@ -468,6 +468,7 @@ mod tests {
     }
 
     #[proptest]
+    #[allow(clippy::len_zero)]
     fn test_len(mut map: RangeSet<u64>) {
         assert_eq!(map.len(), map.iter().count());
         assert_eq!(map.is_empty(), map.len() == 0);


### PR DESCRIPTION
It's used in some tests to make sure that `is_empty()` returns the same value as `len() == 0`.