### PR TITLE
Implement Default manually

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -34,12 +34,21 @@ use serde::{
 /// you can provide equivalent free functions using the `StepFnsT` type parameter.
 /// [`StepLite`] is implemented for all standard integer types,
 /// but not for any third party crate types.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct RangeInclusiveMap<K, V, StepFnsT = K> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeInclusiveStartWrapper<K>, V>,
     _phantom: PhantomData<StepFnsT>,
+}
+
+impl<K, V, StepFnsT> Default for RangeInclusiveMap<K, V, StepFnsT> {
+    fn default() -> Self {
+        Self {
+            btm: BTreeMap::default(),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<K, V, StepFnsT> Hash for RangeInclusiveMap<K, V, StepFnsT>
@@ -1867,6 +1876,14 @@ mod tests {
         map.insert(7..=8, ());
         map.insert(10..=11, ());
         assert_eq!(format!("{:?}", map), "{2..=5: (), 7..=8: (), 10..=11: ()}");
+    }
+
+    // impl Default where T: ?Default
+
+    #[test]
+    fn always_default() {
+        struct NoDefault;
+        RangeInclusiveMap::<NoDefault, NoDefault>::default();
     }
 
     // impl Serialize

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -20,7 +20,7 @@ pub type Intersection<'a, T> = crate::operations::Intersection<'a, RangeInclusiv
 /// Union iterator over two [`RangeInclusiveSet`].
 pub type Union<'a, T> = crate::operations::Union<'a, RangeInclusive<T>, Iter<'a, T>>;
 
-#[derive(Clone, Hash, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as ranges bounded
 /// inclusively below and above `(start..=end)`.
 ///
@@ -29,6 +29,14 @@ pub type Union<'a, T> = crate::operations::Union<'a, RangeInclusive<T>, Iter<'a,
 /// [`RangeInclusiveMap`]: struct.RangeInclusiveMap.html
 pub struct RangeInclusiveSet<T, StepFnsT = T> {
     rm: RangeInclusiveMap<T, (), StepFnsT>,
+}
+
+impl<T, StepFnsT> Default for RangeInclusiveSet<T, StepFnsT> {
+    fn default() -> Self {
+        Self {
+            rm: RangeInclusiveMap::default(),
+        }
+    }
 }
 
 impl<T> RangeInclusiveSet<T, T>
@@ -775,6 +783,14 @@ mod tests {
         set.insert(7..=8);
         set.insert(10..=11);
         assert_eq!(format!("{:?}", set), "{2..=5, 7..=8, 10..=11}");
+    }
+
+    // impl Default where T: ?Default
+
+    #[test]
+    fn always_default() {
+        struct NoDefault;
+        RangeInclusiveSet::<NoDefault>::default();
     }
 
     // impl Serialize

--- a/src/map.rs
+++ b/src/map.rs
@@ -23,11 +23,19 @@ use serde::{
 ///
 /// Contiguous and overlapping ranges that map to the same value
 /// are coalesced into a single range.
-#[derive(Clone, Default, Eq)]
+#[derive(Clone, Eq)]
 pub struct RangeMap<K, V> {
     // Wrap ranges so that they are `Ord`.
     // See `range_wrapper.rs` for explanation.
     pub(crate) btm: BTreeMap<RangeStartWrapper<K>, V>,
+}
+
+impl<K, V> Default for RangeMap<K, V> {
+    fn default() -> Self {
+        Self {
+            btm: BTreeMap::default(),
+        }
+    }
 }
 
 impl<K, V> Hash for RangeMap<K, V>
@@ -1700,6 +1708,14 @@ mod tests {
         map.insert(6..7, ());
         map.insert(8..9, ());
         assert_eq!(format!("{:?}", map), "{2..5: (), 6..7: (), 8..9: ()}");
+    }
+
+    // impl Default where T: ?Default
+
+    #[test]
+    fn always_default() {
+        struct NoDefault;
+        RangeMap::<NoDefault, NoDefault>::default();
     }
 
     // Iterator Tests

--- a/src/set.rs
+++ b/src/set.rs
@@ -20,7 +20,7 @@ pub type Intersection<'a, T> = crate::operations::Intersection<'a, Range<T>, Ite
 /// Union iterator over two [`RangeSet`].
 pub type Union<'a, T> = crate::operations::Union<'a, Range<T>, Iter<'a, T>>;
 
-#[derive(Clone, Hash, Default, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
 /// A set whose items are stored as (half-open) ranges bounded
 /// inclusively below and exclusively above `(start..end)`.
 ///
@@ -29,6 +29,14 @@ pub type Union<'a, T> = crate::operations::Union<'a, Range<T>, Iter<'a, T>>;
 /// [`RangeMap`]: struct.RangeMap.html
 pub struct RangeSet<T> {
     rm: RangeMap<T, ()>,
+}
+
+impl<T> Default for RangeSet<T> {
+    fn default() -> Self {
+        Self {
+            rm: RangeMap::default(),
+        }
+    }
 }
 
 impl<T> RangeSet<T>
@@ -744,6 +752,14 @@ mod tests {
         set.insert(7..8);
         set.insert(10..11);
         assert_eq!(format!("{:?}", set), "{2..5, 7..8, 10..11}");
+    }
+
+    // impl Default where T: ?Default
+
+    #[test]
+    fn always_default() {
+        struct NoDefault;
+        RangeSet::<NoDefault>::default();
     }
 
     // impl Serialize


### PR DESCRIPTION
This allows to use `Default` trait even when
generics do not implement Default.
