### PR TITLE
improve gaps() time complexity for inclusive range map

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -548,7 +548,7 @@ where
         Gaps {
             candidate_needs_plus_one: false,
             candidate_start: outer_range.start(),
-            query_end: &outer_range.end(),
+            query_end: outer_range.end(),
             btm_range_iter: overlap_iter.btm_range_iter,
             // We'll start the candidate range at the start of the outer range
             // without checking what's there. Each time we yield an item,
@@ -825,7 +825,7 @@ where
     type Item = RangeInclusive<K>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(overlap) = self.btm_range_iter.next() {
+        for overlap in self.btm_range_iter.by_ref() {
             let overlap = overlap.0;
 
             // If the range in the map has advanced beyond the query range, return

--- a/src/map.rs
+++ b/src/map.rs
@@ -725,7 +725,7 @@ where
 {
     type Item = Range<K>;
 
-    fn next(&mut self) -> Option<Self::Item> {        
+    fn next(&mut self) -> Option<Self::Item> {
         // Keep track of the next range in the map beyond the current returned range.
         for overlap in self.btm_range_iter.by_ref() {
             let overlap = &overlap.0.range;
@@ -736,13 +736,12 @@ where
                 break;
             }
 
-            let original_start = self.candidate_start;
-            self.candidate_start = &overlap.end;
+            let original_start = core::mem::replace(&mut self.candidate_start, &overlap.end);
 
             // The query range overhangs to the left, return a gap.
             if *original_start < overlap.start {
                 let gap = original_start.clone()..overlap.start.clone();
-                return Some(gap)
+                return Some(gap);
             }
 
             // The remaining query range starts within the current


### PR DESCRIPTION
I didn't initially realize that the inclusive range map is a completely different implementation. Implement an O(log n) initial seek for the inclusive range map, similar to abf6bec733a5e8939cf0d9a93f0f35ed7cee3de2.