### PR TITLE
replace panics with no-ops on empty ranges

### DIFF
--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -243,20 +243,14 @@ where
     /// any existing range _mapping to the same value_, then the ranges
     /// will be coalesced into a single contiguous range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start > end`.
+    /// Inserting an empty range is a no-op.
     pub fn insert(&mut self, range: RangeInclusive<K>, value: V) {
         use core::ops::Bound;
 
-        // Backwards ranges don't make sense.
-        // `RangeInclusive` doesn't enforce this,
-        // and we don't want weird explosions further down
-        // if someone gives us such a range.
-        assert!(
-            range.start() <= range.end(),
-            "Range start can not be after range end"
-        );
+        // Inserting an empty range is a no-op.
+        if range.is_empty() {
+            return;
+        }
 
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.
@@ -379,21 +373,14 @@ where
     /// in the map, then those ranges will be contracted to no
     /// longer cover the removed range.
     ///
-    ///
-    /// # Panics
-    ///
-    /// Panics if range `start > end`.
+    /// Removing an empty range is a no-op.
     pub fn remove(&mut self, range: RangeInclusive<K>) {
         use core::ops::Bound;
 
-        // Backwards ranges don't make sense.
-        // `RangeInclusive` doesn't enforce this,
-        // and we don't want weird explosions further down
-        // if someone gives us such a range.
-        assert!(
-            range.start() <= range.end(),
-            "Range start can not be after range end"
-        );
+        // Removing an empty range is a no-op.
+        if range.is_empty() {
+            return;
+        }
 
         let range_start_wrapper: RangeInclusiveStartWrapper<K> =
             RangeInclusiveStartWrapper::new(range);

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -140,9 +140,7 @@ where
     /// any existing range, then the ranges will be coalesced into
     /// a single contiguous range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start > end`.
+    /// Inserting an empty range is a no-op.
     pub fn insert(&mut self, range: RangeInclusive<T>) {
         self.rm.insert(range, ());
     }
@@ -153,9 +151,7 @@ where
     /// in the set, then those ranges will be contracted to no
     /// longer cover the removed range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start > end`.
+    /// Removing an empty range is a no-op.
     pub fn remove(&mut self, range: RangeInclusive<T>) {
         self.rm.remove(range);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,11 @@ for (range, person) in roster.iter() {
 // 2019-03-04UTC (P7D): Carol
 ```
 
+## Empty ranges
+
+Insert and remove operations in this crate change a subset of the data structure,
+defined by the passed range. When the passed range is empty, the operation
+results in a no-op, similar to adding 0 to a number.
 
 ## Crate features
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -255,13 +255,12 @@ where
     /// any existing range _mapping to the same value_, then the ranges
     /// will be coalesced into a single contiguous range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start >= end`.
+    /// Inserting an empty range is a no-op.
     pub fn insert(&mut self, range: Range<K>, value: V) {
-        // We don't want to have to make empty ranges make sense;
-        // they don't represent anything meaningful in this structure.
-        assert!(range.start < range.end);
+        // Inserting an empty range is a no-op.
+        if range.is_empty() {
+            return;
+        }
 
         // Wrap up the given range so that we can "borrow"
         // it as a wrapper reference to either its start or end.
@@ -368,14 +367,12 @@ where
     /// in the map, then those ranges will be contracted to no
     /// longer cover the removed range.
     ///
-    ///
-    /// # Panics
-    ///
-    /// Panics if range `start >= end`.
+    /// Removing an empty range is a no-op.
     pub fn remove(&mut self, range: Range<K>) {
-        // We don't want to have to make empty ranges make sense;
-        // they don't represent anything meaningful in this structure.
-        assert!(range.start < range.end);
+        // Removing an empty range is a no-op.
+        if range.is_empty() {
+            return;
+        }
 
         let start_wrapper: RangeStartWrapper<K> = RangeStartWrapper::new(range);
         let range = &start_wrapper.end_wrapper.range;

--- a/src/set.rs
+++ b/src/set.rs
@@ -120,9 +120,7 @@ where
     /// any existing range, then the ranges will be coalesced into
     /// a single contiguous range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start >= end`.
+    /// Inserting an empty range is a no-op.
     pub fn insert(&mut self, range: Range<T>) {
         self.rm.insert(range, ());
     }
@@ -133,9 +131,7 @@ where
     /// in the set, then those ranges will be contracted to no
     /// longer cover the removed range.
     ///
-    /// # Panics
-    ///
-    /// Panics if range `start >= end`.
+    /// Removing an empty range is a no-op.
     pub fn remove(&mut self, range: Range<T>) {
         self.rm.remove(range);
     }


### PR DESCRIPTION
Inserts and removals have a clear sensible behavior that should happen when something is done to an empty range: nothing. The range defines the set of keys that may change, so if the range is empty, no keys may change.

While I don't think there is anything else that could possibly happen in these cases, the more important outcome is that there is no longer a risk of random panics that cannot be caught at compile time.