### PR TITLE
Add support for `ordered-float`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
 name = "permutator"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -621,6 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+ "serde",
 ]
 
 [[package]]
@@ -647,6 +661,7 @@ version = "1.7.1"
 dependencies = [
  "chrono",
  "criterion",
+ "ordered-float",
  "permutator",
  "proptest",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 [dependencies]
 quickcheck = { version = "1.0.3", optional = true }
 serde = { version = "1", optional = true }
+ordered-float = { version = "5.3.0", optional = true }
 
 [dev-dependencies]
 permutator = "0.4"
@@ -39,9 +40,10 @@ rustc_version = "0.4"
 serde_json = "1"
 proptest = "1.4"
 test-strategy = "0.4"
+ordered-float = { version = "5.3.0", features = ["proptest"] }
 
 [features]
-serde1 = ["serde"]
+serde1 = ["serde", "ordered-float?/serde"]
 # So we can run doc tests from "README.md".
 nightly = []
 # Enables `RangeMap::new()`, `RangeInclusiveMap::new()`, `RangeSet::new()`,
@@ -50,6 +52,7 @@ nightly = []
 # but is soon to be stabilized: <https://github.com/rust-lang/rust/issues/71835>
 const_fn = []
 quickcheck = ["dep:quickcheck"]
+ordered-float = ["dep:ordered-float"]
 
 [[bench]]
 name = "benches"

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1973,4 +1973,143 @@ mod tests {
             xs == xs
         }
     }
+
+    #[cfg(feature = "ordered-float")]
+    mod ordered_float {
+        use super::*;
+        use ::ordered_float::NotNan;
+
+        type F64 = NotNan<f64>;
+
+        #[proptest]
+        #[allow(clippy::len_zero)]
+        fn test_len(mut map: RangeInclusiveMap<F64, String>) {
+            assert_eq!(map.len(), map.iter().count());
+            assert_eq!(map.is_empty(), map.len() == 0);
+            map.clear();
+            assert_eq!(map.len(), 0);
+            assert!(map.is_empty());
+            assert_eq!(map.iter().count(), 0);
+        }
+
+        #[proptest]
+        fn test_first(set: RangeInclusiveMap<F64, String>) {
+            assert_eq!(
+                set.first_range_value(),
+                set.iter().min_by_key(|(range, _)| range.start())
+            );
+        }
+
+        #[proptest]
+        fn test_last(set: RangeInclusiveMap<F64, String>) {
+            assert_eq!(
+                set.last_range_value(),
+                set.iter().max_by_key(|(range, _)| range.end())
+            );
+        }
+
+        #[proptest]
+        fn test_iter_reversible(set: RangeInclusiveMap<F64, String>) {
+            let forward: Vec<_> = set.iter().collect();
+            let mut backward: Vec<_> = set.iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_into_iter_reversible(set: RangeInclusiveMap<F64, String>) {
+            let forward: Vec<_> = set.clone().into_iter().collect();
+            let mut backward: Vec<_> = set.into_iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_overlapping_reversible(
+            set: RangeInclusiveMap<F64, String>,
+            range: RangeInclusive<F64>,
+        ) {
+            let forward: Vec<_> = set.overlapping(&range).collect();
+            let mut backward: Vec<_> = set.overlapping(&range).rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_arbitrary_map_u8(ranges: Vec<(RangeInclusive<u8>, String)>) {
+            let ranges: Vec<_> = ranges
+                .into_iter()
+                .filter(|(range, _value)| range.start() != range.end())
+                .collect();
+            let set = ranges
+                .iter()
+                .fold(RangeInclusiveMap::new(), |mut set, (range, value)| {
+                    set.insert(range.clone(), value.clone());
+                    set
+                });
+
+            for value in 0..u8::MAX {
+                assert_eq!(
+                    set.get(&value),
+                    ranges
+                        .iter()
+                        .rev()
+                        .find(|(range, _value)| range.contains(&value))
+                        .map(|(_range, value)| value)
+                );
+            }
+        }
+
+        #[proptest]
+        #[allow(deprecated)]
+        fn test_hash(left: RangeInclusiveMap<F64, F64>, right: RangeInclusiveMap<F64, F64>) {
+            use core::hash::{Hash, Hasher, SipHasher};
+
+            let hash = |set: &RangeInclusiveMap<_, _>| {
+                let mut hasher = SipHasher::new();
+                set.hash(&mut hasher);
+                hasher.finish()
+            };
+
+            if left == right {
+                assert!(
+                    hash(&left) == hash(&right),
+                    "if two values are equal, their hash must be equal"
+                );
+            }
+
+            // if the hashes are equal the values might not be the same (collision)
+            if hash(&left) != hash(&right) {
+                assert!(
+                    left != right,
+                    "if two value's hashes are not equal, they must not be equal"
+                );
+            }
+        }
+
+        #[proptest]
+        fn test_ord(left: RangeInclusiveMap<F64, F64>, right: RangeInclusiveMap<F64, F64>) {
+            assert_eq!(
+                left == right,
+                left.cmp(&right).is_eq(),
+                "ordering and equality must match"
+            );
+            assert_eq!(
+                left.cmp(&right),
+                left.partial_cmp(&right).unwrap(),
+                "ordering is total for ordered parameters"
+            );
+        }
+
+        #[test]
+        fn test_from_array() {
+            let mut map = RangeInclusiveMap::new();
+            map.insert(0..=100, "hello");
+            map.insert(200..=300, "world");
+            assert_eq!(
+                map,
+                RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")])
+            );
+        }
+    }
 }

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -846,4 +846,59 @@ mod tests {
             xs == xs
         }
     }
+
+    // ordered-float
+
+    #[cfg(feature = "ordered-float")]
+    mod ordered_float {
+        use super::*;
+        use ::ordered_float::NotNan;
+
+        type F64 = NotNan<f64>;
+
+        #[proptest]
+        fn test_first(set: RangeInclusiveSet<F64>) {
+            assert_eq!(set.first(), set.iter().min_by_key(|range| range.start()));
+        }
+
+        #[proptest]
+        #[allow(clippy::len_zero)]
+        fn test_len(mut map: RangeInclusiveSet<F64>) {
+            assert_eq!(map.len(), map.iter().count());
+            assert_eq!(map.is_empty(), map.len() == 0);
+            map.clear();
+            assert_eq!(map.len(), 0);
+            assert!(map.is_empty());
+            assert_eq!(map.iter().count(), 0);
+        }
+
+        #[proptest]
+        fn test_last(set: RangeInclusiveSet<F64>) {
+            assert_eq!(set.last(), set.iter().max_by_key(|range| range.end()));
+        }
+
+        #[proptest]
+        fn test_iter_reversible(set: RangeInclusiveSet<F64>) {
+            let forward: Vec<_> = set.iter().collect();
+            let mut backward: Vec<_> = set.iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_into_iter_reversible(set: RangeInclusiveSet<F64>) {
+            let forward: Vec<_> = set.clone().into_iter().collect();
+            let mut backward: Vec<_> = set.into_iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_overlapping_reversible(set: RangeInclusiveSet<F64>, range: RangeInclusive<F64>) {
+            let forward: Vec<_> = set.overlapping(&range).collect();
+            let mut backward: Vec<_> = set.overlapping(&range).rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+    }
 }

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -121,6 +121,28 @@ macro_rules! impl_step_lite {
 
 impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
+#[cfg(feature = "ordered-float")]
+macro_rules! impl_step_lite_ordered_float {
+    ($($t:ty)*) => ($(
+        impl StepLite for ordered_float::NotNan<$t> {
+            #[inline]
+            fn add_one(&self) -> Self {
+                // SAFETY: next_up() is well-defined to not be NaN for all non-NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(self.next_up()) }
+            }
+
+            #[inline]
+            fn sub_one(&self) -> Self {
+                // SAFETY: next_down() is well-defined to not be NaN for all non-NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(self.next_down()) }
+            }
+        }
+    )*)
+}
+
+#[cfg(feature = "ordered-float")]
+impl_step_lite_ordered_float!(f32 f64);
+
 // TODO: When on nightly, a blanket implementation for
 // all types that implement `core::iter::Step` instead
 // of the auto-impl above.


### PR DESCRIPTION
As the title states, this adds support for `ordered_float::NotNan<f32 | f64>`. The biggest challenge with doing this externally was the missing of `StepLite` and the tight integration of `StepLite` with e.g. `Debug` (as opposed to `StepFns`, which would have sidestepped the orphan rule). Switching the implementations to use `StepFns` seemed like a larger change over a simpler feature flag integration point with a well-known crate, so hopefully this route makes enough sense to allow.

I could have added it here or added it to `ordered-float`, but given that it's more likely the case that people will seek total ordered float support in `rangemap` rather than rangemap support in `ordered-float`, it made more sense to add it here.

The `unsafe` is optional - it could very well be a `NotNull::new(...).unwrap()`, but given that the core functions guarantee that non-NaN `.next_up()`/`.next_down()` produce non-NaN values, and `new_unchecked()` only mandates the value is, well, not NaN (as opposed to "not +/-inf"), then this contract holds and the result is well-defined.

I did a quick copy/paste of some of the tests to make sure it works as behaved for the `ordered-float` feature but of course they're not comprehensive; I considered wrapping the tests in a macro that emits them for different inner types but figured that was a larger and more intrusive change than what you'd probably accept, so hopefully this is a decent middleground.

---

FWIW we're using rangemap in a constrainable type algebra library for a dist-sys execution engine, so this is a really neat piece of code. Thank you for releasing it :) Was super easy to traverse the codebase.