### PR TITLE
Add support for `ordered-float`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,39 @@ jobs:
         with:
           command: test
           args: --features nightly
+  # We claim to work without the standard library, so make sure we
+  # actually do, with every combination of features that could plausibly
+  # drag it back in.
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          target: thumbv7em-none-eabi
+      - name: build for a bare metal target
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target thumbv7em-none-eabi
+      # Not `quickcheck`: it depends on `getrandom`, which doesn't support
+      # bare metal targets at all, and it only makes sense in tests anyway.
+      - name: build for a bare metal target with serde1 and ordered-float5
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target thumbv7em-none-eabi --features serde1,ordered-float5
   ci-success:
     name: ci
     if: ${{ success() }}
     needs:
       - test
+      - no-std
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,25 @@ jobs:
         with:
           command: test
           args: --features const_fn
+      # Unlike the features above, run this on every non-nightly toolchain
+      # rather than just stable: `ordered-float5` is the feature most likely
+      # to accidentally depend on something newer than our MSRV, because it
+      # deals in float operations that the standard library has only
+      # stabilized comparatively recently.
+      - name: test with ordered-float5
+        uses: actions-rs/cargo@v1
+        if: matrix.toolchain != 'nightly'
+        with:
+          command: test
+          args: --features ordered-float5
+      # `serde1` reaches into `ordered-float` to pick up its `serde` feature,
+      # so make sure the combination of the two actually works.
+      - name: stable test with serde and ordered-float5
+        uses: actions-rs/cargo@v1
+        if: matrix.toolchain == 'stable'
+        with:
+          command: test
+          args: --features serde1,ordered-float5
       - name: nightly test
         uses: actions-rs/cargo@v1
         if: matrix.toolchain == 'nightly'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
 name = "permutator"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -621,6 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+ "serde",
 ]
 
 [[package]]
@@ -647,6 +661,7 @@ version = "1.7.1"
 dependencies = [
  "chrono",
  "criterion",
+ "ordered-float",
  "permutator",
  "proptest",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 [dependencies]
 quickcheck = { version = "1.0.3", optional = true }
 serde = { version = "1", optional = true }
-ordered-float = { version = "5.3.0", optional = true }
+ordered-float = { version = "5.3.0", optional = true, default-features = false }
 
 [dev-dependencies]
 permutator = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 [dependencies]
 quickcheck = { version = "1.0.3", optional = true }
 serde = { version = "1", optional = true }
+ordered-float = { version = "5.3.0", optional = true }
 
 [dev-dependencies]
 permutator = "0.4"
@@ -39,9 +40,10 @@ rustc_version = "0.4"
 serde_json = "1"
 proptest = "1.4"
 test-strategy = "0.4"
+ordered-float = { version = "5.3.0", features = ["proptest"] }
 
 [features]
-serde1 = ["serde"]
+serde1 = ["serde", "ordered-float?/serde"]
 # So we can run doc tests from "README.md".
 nightly = []
 # Enables `RangeMap::new()`, `RangeInclusiveMap::new()`, `RangeSet::new()`,
@@ -50,6 +52,7 @@ nightly = []
 # but is soon to be stabilized: <https://github.com/rust-lang/rust/issues/71835>
 const_fn = []
 quickcheck = ["dep:quickcheck"]
+ordered-float = ["dep:ordered-float"]
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "rangemap"
 version = "1.7.1"
 authors = ["Jeff Parsons <jeff@parsons.io>"]
 edition = "2018"
+# Opt in to the feature resolver that editions 2021 and later get by
+# default, so that dev-dependency features don't leak into normal builds.
+# Without this, our unconditional `ordered-float` dev-dependency turns on
+# that crate's `std` feature for the library too, which both hides and
+# causes `no_std` breakage.
+resolver = "2"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/jeffparsons/rangemap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ nightly = []
 # but is soon to be stabilized: <https://github.com/rust-lang/rust/issues/71835>
 const_fn = []
 quickcheck = ["dep:quickcheck"]
-ordered-float = ["dep:ordered-float"]
+ordered-float5 = ["dep:ordered-float"]
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 
 [dependencies]
 quickcheck = { version = "1.0.3", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }
 ordered-float = { version = "5.3.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ If the choice is not obvious in your case, consider these differences:
   simply by testing their ends for equality. For key types that represent
   points on a continuum, defining these functions may be awkward and error-prone.
   For key types that represent discrete objects, this is usually much
-  more straightforward.
+  more straightforward. (For floats specifically, the **ordered-float5**
+  feature described below provides these functions, taking the successor
+  of a float to be the next representable float.)
 
 
 ## Example: use with Chrono
@@ -111,6 +113,25 @@ rangemap = { version = "1", features = ["serde1"] }
 
 You can similarly enable support for _quickcheck_ by enabling
 the **quickcheck** feature.
+
+If you enable the **ordered-float5** feature it will introduce a dependency
+on the _ordered-float_ crate, and provide the successor and predecessor
+functions that [`RangeInclusiveMap`] and [`RangeInclusiveSet`] need in
+order to accept `NotNan<f32>` and `NotNan<f64>` keys.
+
+Note that the successor of a float is taken to be the _next representable_
+float, one ULP (unit in the last place) away. So ranges that are one ULP
+apart are adjacent, and will therefore be coalesced if they map to the
+same value: inserting `0.0..=1.0` and `1.0000000000000002..=2.0` will
+leave you with the single range `0.0..=2.0`. If that isn't what you want,
+consider using [`RangeMap`] or [`RangeSet`] with half-open ranges instead.
+
+This feature is named for the major version of _ordered-float_ that it
+targets, because enabling it makes that crate part of rangemap's public
+API: you have to be using the same major version of it that we are.
+Naming it this way leaves room to support a future major version
+alongside this one, rather than forcing a breaking change on everyone
+already using the feature.
 
 ## Building without the Rust standard library
 

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1973,4 +1973,143 @@ mod tests {
             xs == xs
         }
     }
+
+    #[cfg(feature = "ordered-float")]
+    mod ordered_float {
+        use super::*;
+        use ::ordered_float::NotNan;
+
+        type F64 = NotNan<f64>;
+
+        #[proptest]
+        #[allow(clippy::len_zero)]
+        fn test_len(mut map: RangeInclusiveMap<F64, String>) {
+            assert_eq!(map.len(), map.iter().count());
+            assert_eq!(map.is_empty(), map.len() == 0);
+            map.clear();
+            assert_eq!(map.len(), 0);
+            assert!(map.is_empty());
+            assert_eq!(map.iter().count(), 0);
+        }
+
+        #[proptest]
+        fn test_first(set: RangeInclusiveMap<F64, String>) {
+            assert_eq!(
+                set.first_range_value(),
+                set.iter().min_by_key(|(range, _)| range.start())
+            );
+        }
+
+        #[proptest]
+        fn test_last(set: RangeInclusiveMap<F64, String>) {
+            assert_eq!(
+                set.last_range_value(),
+                set.iter().max_by_key(|(range, _)| range.end())
+            );
+        }
+
+        #[proptest]
+        fn test_iter_reversible(set: RangeInclusiveMap<F64, String>) {
+            let forward: Vec<_> = set.iter().collect();
+            let mut backward: Vec<_> = set.iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_into_iter_reversible(set: RangeInclusiveMap<F64, String>) {
+            let forward: Vec<_> = set.clone().into_iter().collect();
+            let mut backward: Vec<_> = set.into_iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_overlapping_reversible(
+            set: RangeInclusiveMap<F64, String>,
+            range: RangeInclusive<F64>,
+        ) {
+            let forward: Vec<_> = set.overlapping(&range).collect();
+            let mut backward: Vec<_> = set.overlapping(&range).rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_arbitrary_map_u8(ranges: Vec<(RangeInclusive<u8>, String)>) {
+            let ranges: Vec<_> = ranges
+                .into_iter()
+                .filter(|(range, _value)| range.start() != range.end())
+                .collect();
+            let set = ranges
+                .iter()
+                .fold(RangeInclusiveMap::new(), |mut set, (range, value)| {
+                    set.insert(range.clone(), value.clone());
+                    set
+                });
+
+            for value in 0..u8::MAX {
+                assert_eq!(
+                    set.get(&value),
+                    ranges
+                        .iter()
+                        .rev()
+                        .find(|(range, _value)| range.contains(&value))
+                        .map(|(_range, value)| value)
+                );
+            }
+        }
+
+        #[proptest]
+        #[allow(deprecated)]
+        fn test_hash(left: RangeInclusiveMap<F64, F64>, right: RangeInclusiveMap<F64, F64>) {
+            use core::hash::{Hash, Hasher, SipHasher};
+
+            let hash = |set: &RangeInclusiveMap<_, _>| {
+                let mut hasher = SipHasher::new();
+                set.hash(&mut hasher);
+                hasher.finish()
+            };
+
+            if left == right {
+                assert!(
+                    hash(&left) == hash(&right),
+                    "if two values are equal, their hash must be equal"
+                );
+            }
+
+            // if the hashes are equal the values might not be the same (collision)
+            if hash(&left) != hash(&right) {
+                assert!(
+                    left != right,
+                    "if two value's hashes are not equal, they must not be equal"
+                );
+            }
+        }
+
+        #[proptest]
+        fn test_ord(left: RangeInclusiveMap<F64, F64>, right: RangeInclusiveMap<F64, F64>) {
+            assert_eq!(
+                left == right,
+                left.cmp(&right).is_eq(),
+                "ordering and equality must match"
+            );
+            assert_eq!(
+                left.cmp(&right),
+                left.partial_cmp(&right).unwrap(),
+                "ordering is total for ordered parameters"
+            );
+        }
+
+        #[test]
+        fn test_from_array() {
+            let mut map = RangeInclusiveMap::new();
+            map.insert(0..=100, "hello");
+            map.insert(200..=300, "world");
+            assert_eq!(
+                map,
+                RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")])
+            );
+        }
+    }
 }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -1974,7 +1974,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "ordered-float")]
+    #[cfg(feature = "ordered-float5")]
     mod ordered_float {
         use super::*;
         use ::ordered_float::NotNan;

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -2036,31 +2036,6 @@ mod tests {
         }
 
         #[proptest]
-        fn test_arbitrary_map_u8(ranges: Vec<(RangeInclusive<u8>, String)>) {
-            let ranges: Vec<_> = ranges
-                .into_iter()
-                .filter(|(range, _value)| range.start() != range.end())
-                .collect();
-            let set = ranges
-                .iter()
-                .fold(RangeInclusiveMap::new(), |mut set, (range, value)| {
-                    set.insert(range.clone(), value.clone());
-                    set
-                });
-
-            for value in 0..u8::MAX {
-                assert_eq!(
-                    set.get(&value),
-                    ranges
-                        .iter()
-                        .rev()
-                        .find(|(range, _value)| range.contains(&value))
-                        .map(|(_range, value)| value)
-                );
-            }
-        }
-
-        #[proptest]
         #[allow(deprecated)]
         fn test_hash(left: RangeInclusiveMap<F64, F64>, right: RangeInclusiveMap<F64, F64>) {
             use core::hash::{Hash, Hasher, SipHasher};
@@ -2098,17 +2073,6 @@ mod tests {
                 left.cmp(&right),
                 left.partial_cmp(&right).unwrap(),
                 "ordering is total for ordered parameters"
-            );
-        }
-
-        #[test]
-        fn test_from_array() {
-            let mut map = RangeInclusiveMap::new();
-            map.insert(0..=100, "hello");
-            map.insert(200..=300, "world");
-            assert_eq!(
-                map,
-                RangeInclusiveMap::from([(0..=100, "hello"), (200..=300, "world")])
             );
         }
     }

--- a/src/inclusive_map.rs
+++ b/src/inclusive_map.rs
@@ -2075,5 +2075,62 @@ mod tests {
                 "ordering is total for ordered parameters"
             );
         }
+
+        fn not_nan(x: f64) -> F64 {
+            NotNan::new(x).unwrap()
+        }
+
+        #[test]
+        fn ranges_one_ulp_apart_are_coalesced() {
+            let mut map = RangeInclusiveMap::new();
+            map.insert(not_nan(0.0)..=not_nan(1.0), "hello");
+            map.insert(not_nan(1.0).add_one()..=not_nan(2.0), "hello");
+            assert_eq!(
+                map,
+                RangeInclusiveMap::from([(not_nan(0.0)..=not_nan(2.0), "hello")])
+            );
+        }
+
+        #[test]
+        fn ranges_two_ulps_apart_are_not_coalesced() {
+            let gap = not_nan(1.0).add_one();
+            let mut map = RangeInclusiveMap::new();
+            map.insert(not_nan(0.0)..=not_nan(1.0), "hello");
+            map.insert(gap.add_one()..=not_nan(2.0), "hello");
+            assert_eq!(
+                map,
+                RangeInclusiveMap::from([
+                    (not_nan(0.0)..=not_nan(1.0), "hello"),
+                    (gap.add_one()..=not_nan(2.0), "hello"),
+                ])
+            );
+            // What's between them is a single float.
+            assert_eq!(
+                map.gaps(&(not_nan(0.0)..=not_nan(2.0))).collect::<Vec<_>>(),
+                vec![gap..=gap]
+            );
+        }
+
+        #[test]
+        fn ranges_can_span_the_infinities() {
+            let mut map = RangeInclusiveMap::new();
+            map.insert(
+                not_nan(f64::NEG_INFINITY)..=not_nan(f64::INFINITY),
+                "everything",
+            );
+            map.insert(not_nan(0.0)..=not_nan(1.0), "something");
+
+            // Splitting the outer range mustn't fall over at either infinity,
+            // where stepping saturates instead of moving.
+            assert_eq!(
+                map.iter().map(|(_range, value)| *value).collect::<Vec<_>>(),
+                vec!["everything", "something", "everything"]
+            );
+            assert_eq!(
+                map.gaps(&(not_nan(f64::NEG_INFINITY)..=not_nan(f64::INFINITY)))
+                    .count(),
+                0
+            );
+        }
     }
 }

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -849,7 +849,7 @@ mod tests {
 
     // ordered-float
 
-    #[cfg(feature = "ordered-float")]
+    #[cfg(feature = "ordered-float5")]
     mod ordered_float {
         use super::*;
         use ::ordered_float::NotNan;

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -900,5 +900,17 @@ mod tests {
             backward.reverse();
             assert_eq!(forward, backward);
         }
+
+        fn not_nan(x: f64) -> F64 {
+            NotNan::new(x).unwrap()
+        }
+
+        #[test]
+        fn ranges_one_ulp_apart_are_coalesced() {
+            let mut set = RangeInclusiveSet::new();
+            set.insert(not_nan(0.0)..=not_nan(1.0));
+            set.insert(not_nan(1.0).add_one()..=not_nan(2.0));
+            assert_eq!(set, RangeInclusiveSet::from([not_nan(0.0)..=not_nan(2.0)]));
+        }
     }
 }

--- a/src/inclusive_set.rs
+++ b/src/inclusive_set.rs
@@ -846,4 +846,59 @@ mod tests {
             xs == xs
         }
     }
+
+    // ordered-float
+
+    #[cfg(feature = "ordered-float")]
+    mod ordered_float {
+        use super::*;
+        use ::ordered_float::NotNan;
+
+        type F64 = NotNan<f64>;
+
+        #[proptest]
+        fn test_first(set: RangeInclusiveSet<F64>) {
+            assert_eq!(set.first(), set.iter().min_by_key(|range| range.start()));
+        }
+
+        #[proptest]
+        #[allow(clippy::len_zero)]
+        fn test_len(mut map: RangeInclusiveSet<F64>) {
+            assert_eq!(map.len(), map.iter().count());
+            assert_eq!(map.is_empty(), map.len() == 0);
+            map.clear();
+            assert_eq!(map.len(), 0);
+            assert!(map.is_empty());
+            assert_eq!(map.iter().count(), 0);
+        }
+
+        #[proptest]
+        fn test_last(set: RangeInclusiveSet<F64>) {
+            assert_eq!(set.last(), set.iter().max_by_key(|range| range.end()));
+        }
+
+        #[proptest]
+        fn test_iter_reversible(set: RangeInclusiveSet<F64>) {
+            let forward: Vec<_> = set.iter().collect();
+            let mut backward: Vec<_> = set.iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_into_iter_reversible(set: RangeInclusiveSet<F64>) {
+            let forward: Vec<_> = set.clone().into_iter().collect();
+            let mut backward: Vec<_> = set.into_iter().rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+
+        #[proptest]
+        fn test_overlapping_reversible(set: RangeInclusiveSet<F64>, range: RangeInclusive<F64>) {
+            let forward: Vec<_> = set.overlapping(&range).collect();
+            let mut backward: Vec<_> = set.overlapping(&range).rev().collect();
+            backward.reverse();
+            assert_eq!(forward, backward);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,9 @@ If the choice is not obvious in your case, consider these differences:
   simply by testing their ends for equality. For key types that represent
   points on a continuum, defining these functions may be awkward and error-prone.
   For key types that represent discrete objects, this is usually much
-  more straightforward.
+  more straightforward. (For floats specifically, the **ordered-float5**
+  feature described below provides these functions, taking the successor
+  of a float to be the next representable float.)
 
 
 # Example: use with Chrono
@@ -103,6 +105,25 @@ rangemap = { version = "1", features = ["serde1"] }
 
 You can similarly enable support for _quickcheck_ by enabling
 the **quickcheck** feature.
+
+If you enable the **ordered-float5** feature it will introduce a dependency
+on the _ordered-float_ crate, and provide the successor and predecessor
+functions that [`RangeInclusiveMap`] and [`RangeInclusiveSet`] need in
+order to accept `NotNan<f32>` and `NotNan<f64>` keys.
+
+Note that the successor of a float is taken to be the _next representable_
+float, one ULP (unit in the last place) away. So ranges that are one ULP
+apart are adjacent, and will therefore be coalesced if they map to the
+same value: inserting `0.0..=1.0` and `1.0000000000000002..=2.0` will
+leave you with the single range `0.0..=2.0`. If that isn't what you want,
+consider using [`RangeMap`] or [`RangeSet`] with half-open ranges instead.
+
+This feature is named for the major version of _ordered-float_ that it
+targets, because enabling it makes that crate part of rangemap's public
+API: you have to be using the same major version of it that we are.
+Naming it this way leaves room to support a future major version
+alongside this one, rather than forcing a breaking change on everyone
+already using the feature.
 
 
 ## Building without the Rust standard library

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -121,7 +121,8 @@ macro_rules! impl_step_lite {
 
 impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
-// The successor of a float is the next representable float, i.e. one ULP away.
+// The successor of a float is the next representable float,
+// i.e. one ULP (unit in the last place) away.
 //
 // We can't use the standard library's `next_up` and `next_down` for this
 // because they were only stabilised in Rust 1.86, well beyond our MSRV,

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -121,27 +121,75 @@ macro_rules! impl_step_lite {
 
 impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
+// The successor of a float is the next representable float, i.e. one ULP away.
+//
+// We can't use the standard library's `next_up` and `next_down` for this
+// because they were only stabilised in Rust 1.86, well beyond our MSRV,
+// so we reimplement them here. These mirror the standard library's versions
+// exactly, including their treatment of zeroes (`-0.0` and `0.0` share the
+// same neighbours, which agrees with how `NotNan` orders them) and their
+// saturation at the infinities. `StepLite` explicitly allows saturating
+// at the ends of the range.
+//
+// We don't need the standard library's NaN check, because `NotNan` has
+// already ruled that out for us.
 #[cfg(feature = "ordered-float")]
-macro_rules! impl_step_lite_ordered_float {
-    ($($t:ty)*) => ($(
+macro_rules! impl_step_lite_not_nan {
+    ($($t:ty => $bits:ty),* $(,)?) => ($(
         impl StepLite for ordered_float::NotNan<$t> {
             #[inline]
             fn add_one(&self) -> Self {
-                // SAFETY: next_up() is well-defined to not be NaN for all non-NaN.
-                unsafe { ordered_float::NotNan::new_unchecked(self.next_up()) }
+                const SIGN_MASK: $bits = 1 << (<$bits>::BITS - 1);
+                // Smallest positive subnormal.
+                const TINY_BITS: $bits = 1;
+
+                let bits = self.into_inner().to_bits();
+                let next_bits = if bits == <$t>::INFINITY.to_bits() {
+                    bits
+                } else {
+                    let abs = bits & !SIGN_MASK;
+                    if abs == 0 {
+                        TINY_BITS
+                    } else if bits == abs {
+                        bits + 1
+                    } else {
+                        bits - 1
+                    }
+                };
+
+                // SAFETY: the successor of a non-NaN float is never NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(<$t>::from_bits(next_bits)) }
             }
 
             #[inline]
             fn sub_one(&self) -> Self {
-                // SAFETY: next_down() is well-defined to not be NaN for all non-NaN.
-                unsafe { ordered_float::NotNan::new_unchecked(self.next_down()) }
+                const SIGN_MASK: $bits = 1 << (<$bits>::BITS - 1);
+                // Smallest negative subnormal.
+                const NEG_TINY_BITS: $bits = (1 << (<$bits>::BITS - 1)) | 1;
+
+                let bits = self.into_inner().to_bits();
+                let next_bits = if bits == <$t>::NEG_INFINITY.to_bits() {
+                    bits
+                } else {
+                    let abs = bits & !SIGN_MASK;
+                    if abs == 0 {
+                        NEG_TINY_BITS
+                    } else if bits == abs {
+                        bits - 1
+                    } else {
+                        bits + 1
+                    }
+                };
+
+                // SAFETY: the predecessor of a non-NaN float is never NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(<$t>::from_bits(next_bits)) }
             }
         }
     )*)
 }
 
 #[cfg(feature = "ordered-float")]
-impl_step_lite_ordered_float!(f32 f64);
+impl_step_lite_not_nan!(f32 => u32, f64 => u64);
 
 // TODO: When on nightly, a blanket implementation for
 // all types that implement `core::iter::Step` instead

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -121,6 +121,28 @@ macro_rules! impl_step_lite {
 
 impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 
+#[cfg(feature = "ordered-float")]
+macro_rules! impl_step_lite_ordered_float {
+    ($($t:ty)*) => ($(
+        impl StepLite for ordered_float::NotNan<$t> {
+            #[inline]
+            fn add_one(&self) -> Self {
+                // SAFETY: next_up() is well-defined to not be NaN for all non-NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(self.next_up()) }
+            }
+
+            #[inline]
+            fn sub_one(&self) -> Self {
+                // SAFETY: next_down() is well-defined to not be NaN for all non-NaN.
+                unsafe { ordered_float::NotNan::new_unchecked(self.next_down()) }
+            }
+        }
+    )*)
+}
+
+#[cfg(feature = "ordered-float")]
+impl_step_lite_ordered_float!(f32 f64);
+
 // TODO: When on nightly, a blanket implementation for
 // all types that implement `core::iter::Step` instead
 // of the auto-impl above.

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -249,3 +249,105 @@ where
         start.sub_one()
     }
 }
+
+#[cfg(all(test, feature = "ordered-float5"))]
+mod tests {
+    use super::*;
+    use alloc as std;
+    use alloc::format;
+    use ordered_float::NotNan;
+    use proptest::prelude::*;
+    use test_strategy::proptest;
+
+    fn not_nan(x: f64) -> NotNan<f64> {
+        NotNan::new(x).unwrap()
+    }
+
+    fn not_nan_32(x: f32) -> NotNan<f32> {
+        NotNan::new(x).unwrap()
+    }
+
+    // We can't check any of these against the standard library's `next_up`
+    // and `next_down`, because those are newer than our MSRV, so spell out
+    // what "one ULP away" means in terms of the underlying bit patterns
+    // instead.
+
+    #[test]
+    fn steps_to_the_next_representable_float() {
+        assert_eq!(
+            not_nan(1.0).add_one(),
+            not_nan(f64::from_bits(1.0f64.to_bits() + 1))
+        );
+        assert_eq!(
+            not_nan(1.0).sub_one(),
+            not_nan(f64::from_bits(1.0f64.to_bits() - 1))
+        );
+
+        // Negative values run the other way through the bit patterns.
+        assert_eq!(
+            not_nan(-1.0).add_one(),
+            not_nan(f64::from_bits((-1.0f64).to_bits() - 1))
+        );
+        assert_eq!(
+            not_nan(-1.0).sub_one(),
+            not_nan(f64::from_bits((-1.0f64).to_bits() + 1))
+        );
+    }
+
+    #[test]
+    fn steps_from_zero_to_the_smallest_subnormals() {
+        let tiny = f64::from_bits(1);
+        assert_eq!(not_nan(0.0).add_one(), not_nan(tiny));
+        assert_eq!(not_nan(0.0).sub_one(), not_nan(-tiny));
+
+        // `NotNan` considers `-0.0` and `0.0` equal, so they have to step
+        // to the same neighbours as each other.
+        assert_eq!(not_nan(-0.0).add_one(), not_nan(tiny));
+        assert_eq!(not_nan(-0.0).sub_one(), not_nan(-tiny));
+    }
+
+    #[test]
+    fn steps_saturate_at_the_infinities() {
+        assert_eq!(not_nan(f64::MAX).add_one(), not_nan(f64::INFINITY));
+        assert_eq!(not_nan(f64::INFINITY).add_one(), not_nan(f64::INFINITY));
+        assert_eq!(not_nan(f64::MIN).sub_one(), not_nan(f64::NEG_INFINITY));
+        assert_eq!(
+            not_nan(f64::NEG_INFINITY).sub_one(),
+            not_nan(f64::NEG_INFINITY)
+        );
+
+        // The infinities still step back inwards, though.
+        assert_eq!(not_nan(f64::INFINITY).sub_one(), not_nan(f64::MAX));
+        assert_eq!(not_nan(f64::NEG_INFINITY).add_one(), not_nan(f64::MIN));
+    }
+
+    #[test]
+    fn f32_steps_the_same_way_as_f64() {
+        assert_eq!(
+            not_nan_32(1.0).add_one(),
+            not_nan_32(f32::from_bits(1.0f32.to_bits() + 1))
+        );
+        assert_eq!(not_nan_32(0.0).add_one(), not_nan_32(f32::from_bits(1)));
+        assert_eq!(not_nan_32(-0.0).add_one(), not_nan_32(f32::from_bits(1)));
+        assert_eq!(not_nan_32(f32::MAX).add_one(), not_nan_32(f32::INFINITY));
+        assert_eq!(
+            not_nan_32(f32::INFINITY).add_one(),
+            not_nan_32(f32::INFINITY)
+        );
+    }
+
+    #[proptest]
+    fn steps_are_reversible(x: NotNan<f64>) {
+        // Not at the infinities, where stepping outwards saturates.
+        prop_assume!(x.into_inner().is_finite());
+        assert_eq!(x.add_one().sub_one(), x);
+        assert_eq!(x.sub_one().add_one(), x);
+    }
+
+    #[proptest]
+    fn steps_move_in_the_right_direction(x: NotNan<f64>) {
+        prop_assume!(x.into_inner().is_finite());
+        assert!(x.add_one() > x);
+        assert!(x.sub_one() < x);
+    }
+}

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -133,6 +133,9 @@ impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 //
 // We don't need the standard library's NaN check, because `NotNan` has
 // already ruled that out for us.
+//
+// TODO: Delete all of this the next time we raise our MSRV past 1.86,
+// and call `next_up`/`next_down` directly instead.
 #[cfg(feature = "ordered-float5")]
 macro_rules! impl_step_lite_not_nan {
     ($($t:ty => $bits:ty),* $(,)?) => ($(

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -157,8 +157,9 @@ macro_rules! impl_step_lite_not_nan {
                     }
                 };
 
-                // SAFETY: the successor of a non-NaN float is never NaN.
-                unsafe { ordered_float::NotNan::new_unchecked(<$t>::from_bits(next_bits)) }
+                // The successor of a non-NaN float is never NaN.
+                ordered_float::NotNan::new(<$t>::from_bits(next_bits))
+                    .expect("successor of a non-NaN float is never NaN")
             }
 
             #[inline]
@@ -181,8 +182,9 @@ macro_rules! impl_step_lite_not_nan {
                     }
                 };
 
-                // SAFETY: the predecessor of a non-NaN float is never NaN.
-                unsafe { ordered_float::NotNan::new_unchecked(<$t>::from_bits(next_bits)) }
+                // The predecessor of a non-NaN float is never NaN.
+                ordered_float::NotNan::new(<$t>::from_bits(next_bits))
+                    .expect("predecessor of a non-NaN float is never NaN")
             }
         }
     )*)

--- a/src/std_ext.rs
+++ b/src/std_ext.rs
@@ -133,7 +133,7 @@ impl_step_lite!(usize u8 u16 u32 u64 u128 i8 i16 i32 i64 i128);
 //
 // We don't need the standard library's NaN check, because `NotNan` has
 // already ruled that out for us.
-#[cfg(feature = "ordered-float")]
+#[cfg(feature = "ordered-float5")]
 macro_rules! impl_step_lite_not_nan {
     ($($t:ty => $bits:ty),* $(,)?) => ($(
         impl StepLite for ordered_float::NotNan<$t> {
@@ -190,7 +190,7 @@ macro_rules! impl_step_lite_not_nan {
     )*)
 }
 
-#[cfg(feature = "ordered-float")]
+#[cfg(feature = "ordered-float5")]
 impl_step_lite_not_nan!(f32 => u32, f64 => u64);
 
 // TODO: When on nightly, a blanket implementation for


### PR DESCRIPTION
Supersedes #118. Adds support for using `ordered_float::NotNan<f32>` and
`ordered_float::NotNan<f64>` as keys of `RangeInclusiveMap` and
`RangeInclusiveSet`, behind a new opt-in feature.

The feature is entirely @Qix-'s work, and this branch is based directly on
his commit so that it keeps his authorship. Everything after it is follow-up
work from reviewing it. Sorry for taking so long to get to this one!

### Also in here, beyond #118

- The feature is called `ordered-float5`, not `ordered-float` — it puts a
  foreign type in our public API, so it's named for the major version it
  targets, as `serde1` is. @Qix-, this'll need a rename wherever you're
  patching it in.
- Fixes a pre-existing break, unrelated to this feature: `serde1` has never
  worked without the standard library, because `serde`'s default features
  include `std`. Turned up by a new CI job.
- Switches to the version 2 feature resolver, without which dev-dependency
  features leak into normal builds. No change to
  `cargo tree -e features --all-features` or `Cargo.lock`.
