### PR TITLE
Check formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,33 @@ jobs:
         with:
           command: build
           args: --target thumbv7em-none-eabi --features serde1,ordered-float5
+  # Only on stable: rustfmt's output changes from time to time, so running
+  # this across the whole toolchain matrix would just mean two versions
+  # disagreeing about what "formatted" means.
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          components: rustfmt
+      - name: check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
   ci-success:
     name: ci
     if: ${{ success() }}
     needs:
       - test
       - no-std
+      - formatting
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/src/map.rs
+++ b/src/map.rs
@@ -819,7 +819,9 @@ where
     }
 }
 
-impl<K: Ord + Clone, V: PartialEq + Clone, const N: usize> From<[(Range<K>, V); N]> for RangeMap<K, V> {
+impl<K: Ord + Clone, V: PartialEq + Clone, const N: usize> From<[(Range<K>, V); N]>
+    for RangeMap<K, V>
+{
     fn from(value: [(Range<K>, V); N]) -> Self {
         let mut map = Self::new();
         for (range, value) in IntoIterator::into_iter(value) {


### PR DESCRIPTION
Takes up @Qix-'s offer from #118.

- **Reformat** — `cargo fmt` had drifted on one `impl` header in `src/map.rs`.
- **Check formatting in CI** — only on stable, in its own job, since rustfmt's output changes from time to time and running it across the whole toolchain matrix would mean two versions disagreeing about what "formatted" means.
